### PR TITLE
Add invisible username fields to create and login

### DIFF
--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -25,6 +25,10 @@ code {
   margin: 0 auto;
 }
 
+.hidden {
+  display: none;
+}
+
 /* Wrapper for page content to push down footer */
 #wrap {
   min-height: 100%;

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -26,7 +26,7 @@ code {
 }
 
 .hidden {
-  display: none;
+  display: none !important;
 }
 
 /* Wrapper for page content to push down footer */
@@ -238,7 +238,7 @@ li.story.cursor {
   border: 3px solid #484948;
 }
 
-li.story .story-body-container { 
+li.story .story-body-container {
   display: none;
 }
 

--- a/app/views/first_run/password.erb
+++ b/app/views/first_run/password.erb
@@ -5,6 +5,11 @@
   <p><%= t('first_run.password.description') %></p>
   <hr />
   <form id="password_setup" method="POST" action="/setup/password">
+    <div class="control-group hidden">
+      <input name="username" id="username" type="text" value="stringer" />
+      <label id="username-label" class="field-label" for="username"><%= t('first_run.password.fields.username') %></label>
+      <span class="help-block"><%= t('first_run.password.help.username') %></span>
+    </div>
     <div class="control-group">
       <input name="password" id="password" type="password" autofocus="autofocus"/ >
       <i class="icon-lock field-icon"></i>

--- a/app/views/first_run/password.erb
+++ b/app/views/first_run/password.erb
@@ -5,11 +5,7 @@
   <p><%= t('first_run.password.description') %></p>
   <hr />
   <form id="password_setup" method="POST" action="/setup/password">
-    <div class="control-group hidden">
-      <input name="username" id="username" type="text" value="stringer" />
-      <label id="username-label" class="field-label" for="username"><%= t('first_run.password.fields.username') %></label>
-      <span class="help-block"><%= t('first_run.password.help.username') %></span>
-    </div>
+    <input class="hidden" value="username" />
     <div class="control-group">
       <input name="password" id="password" type="password" autofocus="autofocus"/ >
       <i class="icon-lock field-icon"></i>

--- a/app/views/sessions/new.erb
+++ b/app/views/sessions/new.erb
@@ -5,11 +5,7 @@
   <hr />
 
   <form method="POST" id="login" action="/login">
-    <div class="control-group hidden">
-      <input name="username" id="username" type="text" value="stringer" />
-      <label id="username-label" class="field-label" for="username"><%= t('sessions.new.fields.username') %></label>
-      <span class="help-block"><%= t('sessions.new.help.username') %></span>
-    </div>
+    <input class="hidden" value="username" />
     <div class="control-group">
       <input name="password" id="password" type="password" autofocus="autofocus" />
       <i class="icon-lock field-icon"></i>

--- a/app/views/sessions/new.erb
+++ b/app/views/sessions/new.erb
@@ -5,6 +5,11 @@
   <hr />
 
   <form method="POST" id="login" action="/login">
+    <div class="control-group hidden">
+      <input name="username" id="username" type="text" value="stringer" />
+      <label id="username-label" class="field-label" for="username"><%= t('sessions.new.fields.username') %></label>
+      <span class="help-block"><%= t('sessions.new.help.username') %></span>
+    </div>
     <div class="control-group">
       <input name="password" id="password" type="password" autofocus="autofocus" />
       <i class="icon-lock field-icon"></i>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,8 +48,11 @@ en:
         next: Next
         password: Password
         password_confirmation: Confirm
+        username: User name
       flash:
         passwords_dont_match: Hey, your password confirmation didn't match. Try again.
+      help:
+        username: Please do not change the user name.
       subtitle: 'There is only one user: you.'
       title: Stringer is
   flash:
@@ -122,8 +125,11 @@ en:
       fields:
         password: Password
         submit: Login
+        username: User name
       flash:
         wrong_password: That's the wrong password. Try again.
+      help:
+        username: Please do not change the user name.
       rss: RSS
       subtitle: Welcome back, friend.
       title: Stringer speaks

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,11 +48,8 @@ en:
         next: Next
         password: Password
         password_confirmation: Confirm
-        username: User name
       flash:
         passwords_dont_match: Hey, your password confirmation didn't match. Try again.
-      help:
-        username: Please do not change the user name.
       subtitle: 'There is only one user: you.'
       title: Stringer is
   flash:
@@ -125,11 +122,8 @@ en:
       fields:
         password: Password
         submit: Login
-        username: User name
       flash:
         wrong_password: That's the wrong password. Try again.
-      help:
-        username: Please do not change the user name.
       rss: RSS
       subtitle: Welcome back, friend.
       title: Stringer speaks


### PR DESCRIPTION
Functionality is unchanged (the user only sees the password field), but the invisible username field coerces Safari into prompting to save the password.