### PR TITLE
Set APP_URL for Heroku

### DIFF
--- a/docs/Heroku.md
+++ b/docs/Heroku.md
@@ -4,7 +4,7 @@ cd stringer
 heroku create
 git push heroku master
 
-heroku config:set APP_URL=`heroku apps:info | grep -o 'http[^"]*/$'`
+heroku config:set APP_URL=`heroku apps:info --shell | grep web_url | cut -d= -f2`
 heroku config:set SECRET_TOKEN=`openssl rand -hex 20`
 
 heroku run rake db:migrate

--- a/docs/Heroku.md
+++ b/docs/Heroku.md
@@ -4,7 +4,7 @@ cd stringer
 heroku create
 git push heroku master
 
-heroku config:set APP_URL=`heroku apps:info | grep -o 'http[^"]*'`
+heroku config:set APP_URL=`heroku apps:info | grep -o 'http[^"]*/$'`
 heroku config:set SECRET_TOKEN=`openssl rand -hex 20`
 
 heroku run rake db:migrate


### PR DESCRIPTION
When I created new app on Heroku and set APP_URL, I got a following error.

```
 !    Usage: heroku config:set KEY1=VALUE1 [KEY2=VALUE2 ...]
 !    Must specify KEY and VALUE to set.
```

`heroku apps:info` recently give me two urls, Git URL and Web URL.

ex.
Git URL:       https://git.heroku.com/TESTAPP-cedar-14.git
Web URL:       https://TESTAPP-cedar-14.herokuapp.com/

To set APP_URL I modified regexp to get only Web URL.
Is there more better way to do?