### PR TITLE
Ruby 2.2 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: ruby
 rvm:
   - 2.0.0
   - 2.1.0
-before_install: 
+  - 2.2.0
+before_install:
   - gem update bundler
   - sed -i '1d' Gemfile
 before_script:
@@ -15,3 +16,4 @@ script:
 matrix:
   allow_failures:
     - rvm: 2.1.0
+    - rvm: 2.2.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     racksh (1.0.0)
       rack (>= 1.0)
       rack-test (>= 0.5)
-    raindrops (0.12.0)
+    raindrops (0.13.0)
     rake (10.1.1)
     rest-client (1.6.7)
       mime-types (>= 1.16)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
     hpricot (0.8.6)
     i18n (0.6.9)
     jsmin (1.0.1)
-    kgio (2.8.1)
+    kgio (2.9.3)
     loofah (2.0.0)
       nokogiri (>= 1.5.9)
     method_source (0.8.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
       simplecov (>= 0.7)
       term-ansicolor
       thor
-    curb (0.8.5)
+    curb (0.8.6)
     debugger-linecache (1.2.0)
     delayed_job (4.0.0)
       activesupport (>= 3.0, < 4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     sinatra-flash (0.3.0)
       sinatra (>= 1.0.0)
     slop (3.4.7)
-    sqlite3 (1.3.8)
+    sqlite3 (1.3.10)
     term-ansicolor (1.2.2)
       tins (~> 0.8)
     thor (0.18.1)


### PR DESCRIPTION
Updates some dependencies which are required for ruby 2.2.0. I've tested all of them on ruby 2.0.0 and 2.1.5 to make sure they don't break on those rubies.

This will make https://github.com/swanson/stringer/issues/364 easier. :)