### PR TITLE
support for relative base url

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -34,6 +34,7 @@ class Stringer < Sinatra::Base
     set :session_secret, ENV["SECRET_TOKEN"] || "secret!"
     enable :logging
     enable :method_override
+    enable :prefixed_redirects
 
     ActiveRecord::Base.include_root_in_json = false
   end
@@ -55,6 +56,10 @@ class Stringer < Sinatra::Base
 
     def t(*args)
       I18n.t(*args)
+    end
+
+    def u(addr)
+      uri(addr, false, true)
     end
   end
 

--- a/app/helpers/authentication_helpers.rb
+++ b/app/helpers/authentication_helpers.rb
@@ -9,6 +9,7 @@ module Sinatra
     end
 
     def needs_authentication?(path)
+      path = uri(nil, false, false)
       return false if ENV['RACK_ENV'] == 'test'
       return false if !UserRepository.setup_complete?
       return false if path == "/login" || path == "/logout"

--- a/app/public/css/font-awesome-min.css
+++ b/app/public/css/font-awesome-min.css
@@ -24,11 +24,11 @@
  */
  @font-face{
   font-family:'FontAwesome';
-  src:url('/fonts/fontawesome-webfont.eot?v=3.1.0');
-  src:url('/fonts/fontawesome-webfont.eot?#iefix&v=3.1.0') format('embedded-opentype'),
-  url('/fonts/fontawesome-webfont.woff?v=3.1.0') format('woff'),
-  url('/fonts/fontawesome-webfont.ttf?v=3.1.0') format('truetype'),
-  url('/fonts/fontawesome-webfont.svg#fontawesomeregular?v=3.1.0') format('svg');
+  src:url('../fonts/fontawesome-webfont.eot?v=3.1.0');
+  src:url('../fonts/fontawesome-webfont.eot?#iefix&v=3.1.0') format('embedded-opentype'),
+  url('../fonts/fontawesome-webfont.woff?v=3.1.0') format('woff'),
+  url('../fonts/fontawesome-webfont.ttf?v=3.1.0') format('truetype'),
+  url('../fonts/fontawesome-webfont.svg#fontawesomeregular?v=3.1.0') format('svg');
   font-weight:normal;
   font-style:normal}
 

--- a/app/views/feeds/add.erb
+++ b/app/views/feeds/add.erb
@@ -7,7 +7,7 @@
   <hr />
   <p><%= t('feeds.add.description') %></p>
   <hr />
-  <form id="add-feed-setup" method="POST" action="/feeds">
+  <form id="add-feed-setup" method="POST" action="<%= u("/feeds") %>">
     <div class="control-group">
       <input name="feed_url" id="feed-url" type="text" autofocus="autofocus" value="<%= @feed_url %>"/>
       <i class="icon-rss field-icon"></i>

--- a/app/views/feeds/edit.erb
+++ b/app/views/feeds/edit.erb
@@ -5,7 +5,7 @@
 <div class="setup" id="add-feed-container">
   <h1><%= @feed.name %></h1>
   <hr />
-    <form id="add-feed-setup" method="POST" action="/feeds/<%= @feed.id %>">
+    <form id="add-feed-setup" method="POST" action="<%= u("/feeds/") %><%= @feed.id %>">
       <input type="hidden" name="_method" value="PUT">
       <input type="hidden" name="feed_id" value="<%= @feed.id %>">
       <div class="control-group">

--- a/app/views/feeds/import.erb
+++ b/app/views/feeds/import.erb
@@ -8,9 +8,9 @@
   </p>
   <hr />
 
-  <form id="import" method="POST" action="/feeds/import" enctype="multipart/form-data">
+  <form id="import" method="POST" action="<%= u("/feeds/import") %>" enctype="multipart/form-data">
     <input id="opml_file" name="opml_file" type="file" title="<%= t('import.fields.import') %>" class="btn-primary" />
-    <a href="/setup/tutorial" id="skip" class="btn pull-right"><%= t('import.fields.not_now') %></a>
+    <a href="<%= u("/setup/tutorial") %>" id="skip" class="btn pull-right"><%= t('import.fields.not_now') %></a>
   </form>
 </div>
 

--- a/app/views/feeds/index.erb
+++ b/app/views/feeds/index.erb
@@ -12,7 +12,7 @@
 </div>
 <% else %>
   <div id="add-some-feeds">
-    <p><%= t('feeds.index.add_some_feeds', :add => '<a href="/feeds/new">'+t('feeds.index.add')+'</a>') %></p>
+    <p><%= t('feeds.index.add_some_feeds', :add => '<a href="'+u('/feeds/new')+'">'+t('feeds.index.add')+'</a>') %></p>
   </div>
 <% end %>
 

--- a/app/views/first_run/password.erb
+++ b/app/views/first_run/password.erb
@@ -4,7 +4,7 @@
   <hr />
   <p><%= t('first_run.password.description') %></p>
   <hr />
-  <form id="password_setup" method="POST" action="/setup/password">
+  <form id="password_setup" method="POST" action="<%= u("/setup/password") %>">
     <input class="hidden" value="username" />
     <div class="control-group">
       <input name="password" id="password" type="password" autofocus="autofocus"/ >

--- a/app/views/heroku.erb
+++ b/app/views/heroku.erb
@@ -15,5 +15,5 @@
 </div>
 
 <div class="center">
-  <a href="/" id="start" class="btn btn-primary"><%= t('tutorial.ready') %></a>
+  <a href="<%= u("/") %>" id="start" class="btn btn-primary"><%= t('tutorial.ready') %></a>
 </div>

--- a/app/views/layout.erb
+++ b/app/views/layout.erb
@@ -7,8 +7,8 @@
     </title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="shortcut icon" href="/img/favicon.png">
-    <link rel="apple-touch-icon-precomposed" href="/img/apple-touch-icon-precomposed.png">
+    <link rel="shortcut icon" href="<%= u("/img/favicon.png") %>">
+    <link rel="apple-touch-icon-precomposed" href="<%= u("/img/apple-touch-icon-precomposed.png") %>">
     <link href="//fonts.googleapis.com/css?family=Lato:300,400,700,900,400italic" rel="stylesheet" type="text/css">
 
     <%= yield_content :head %>

--- a/app/views/partials/_action_bar.erb
+++ b/app/views/partials/_action_bar.erb
@@ -5,22 +5,21 @@
       <%= render_partial :mark_all_as_read_form,
                         {stories: stories} %>
     </a>
-    <a class="btn" href="/" id="refresh" title="<%= t('partials.action_bar.refresh') %>">
+    <a class="btn" href="<%= u("/") %>" id="refresh" title="<%= t('partials.action_bar.refresh') %>">
       <i class="icon-repeat"></i>
     </a>
   </div>
-
   <div class="pull-right">
-    <a class="btn btn-primary" id="starred" href="/starred" title="<%= t('partials.action_bar.starred_stories') %>">
+    <a class="btn btn-primary" id="starred" href="<%= u("/starred") %>" title="<%= t('partials.action_bar.starred_stories') %>">
       <i class="icon-star"></i>
     </a>
-    <a class="btn btn-primary" id="archive" href="/archive" title="<%= t('partials.action_bar.archived_stories') %>">
+    <a class="btn btn-primary" id="archive" href="<%= u("/archive") %>" title="<%= t('partials.action_bar.archived_stories') %>">
       <i class="icon-time"></i>
     </a>
-    <a class="btn btn-primary" id="feeds" href="/feeds" title="<%= t('partials.action_bar.view_feeds') %>">
+    <a class="btn btn-primary" id="feeds" href="<%= u("/feeds") %>" title="<%= t('partials.action_bar.view_feeds') %>">
       <i class="icon-list"></i>
     </a>
-    <a class="btn btn-primary" id="add-feed" href="/feeds/new" title="<%= t('partials.action_bar.add_feed') %>">
+    <a class="btn btn-primary" id="add-feed" href="<%= u("/feeds/new") %>" title="<%= t('partials.action_bar.add_feed') %>">
       <i class="icon-plus"></i>
     </a>
   </div>

--- a/app/views/partials/_feed.erb
+++ b/app/views/partials/_feed.erb
@@ -3,7 +3,7 @@
     <div class="span7 feed-title-container">
       <p class="feed-title <%= feed.has_unread_stories ? "feed-unread" : "" %>">
         <i class="icon-circle status <%= feed.status_bubble %>" data-toggle="tooltip" title="<%= t("partials.feed.status_bubble.#{feed.status_bubble}") if feed.status_bubble %>" data-placement="left"></i>
-        <a href="/feed/<%= feed.id %>">
+        <a href="<%= u("/feed/") %><%= feed.id %>">
           <% if feed.has_unread_stories %>
             (<%= feed.unread_stories.count %>)
           <% end %>
@@ -26,7 +26,7 @@
         <a class="icon-external-link" href="<%= feed.url %>"></a>
       </span>
       <span class="edit-feed">
-        <a class="icon-edit" href="<%= "/feeds/#{feed.id}/edit" %>"></a>
+        <a class="icon-edit" href="<%= u("/feeds/#{feed.id}/edit") %>"></a>
       </span>
       <span class="remove-feed">
         <a class="icon-remove"></a>

--- a/app/views/partials/_feed_action_bar.erb
+++ b/app/views/partials/_feed_action_bar.erb
@@ -1,21 +1,21 @@
 <div class="row-fluid">
   <div class="pull-left">
-    <a class="btn" id="home" href="/news" title="<%= t('partials.feed_action_bar.home') %>">
+    <a class="btn" id="home" href="<%= u("/news") %>" title="<%= t('partials.feed_action_bar.home') %>">
       <i class="icon-reply"></i>
     </a>
   </div>
 
   <div class="pull-right">
-    <a class="btn btn-primary" id="starred" href="/starred" title="<%= t('partials.feed_action_bar.starred_stories') %>">
+    <a class="btn btn-primary" id="starred" href="<%= u("/starred") %>" title="<%= t('partials.feed_action_bar.starred_stories') %>">
       <i class="icon-star"></i>
     </a>
-    <a class="btn btn-primary" id="archive" href="/archive" title="<%= t('partials.feed_action_bar.archived_stories') %>">
+    <a class="btn btn-primary" id="archive" href="<%= u("/archive") %>" title="<%= t('partials.feed_action_bar.archived_stories') %>">
       <i class="icon-time"></i>
     </a>
-    <a class="btn btn-primary" id="feeds" href="/feeds" title="<%= t('partials.feed_action_bar.feeds') %>">
+    <a class="btn btn-primary" id="feeds" href="<%= u("/feeds") %>" title="<%= t('partials.feed_action_bar.feeds') %>">
       <i class="icon-list"></i>
     </a>
-    <a class="btn btn-primary" id="add-feed" href="/feeds/new" title="<%= t('partials.feed_action_bar.add_feed') %>">
+    <a class="btn btn-primary" id="add-feed" href="<%= u("/feeds/new") %>" title="<%= t('partials.feed_action_bar.add_feed') %>">
       <i class="icon-plus"></i>
     </a>
   </div>

--- a/app/views/partials/_footer.erb
+++ b/app/views/partials/_footer.erb
@@ -3,11 +3,11 @@
     <div class="span6">
       <ul class="footer-links">
         <% if current_user %>
-          <li><a href="/logout"><%= t('layout.logout') %></a></li>
+          <li><a href="<%= u("/logout") %>"><%= t('layout.logout') %></a></li>
           <li class="muted">·</li>
-          <li><a href="/feeds/import"><%= t('layout.import') %></a></li>
+          <li><a href="<%= u("/feeds/import") %>"><%= t('layout.import') %></a></li>
           <li class="muted">·</li>
-          <li><a href="/feeds/export"><%= t('layout.export') %></a></li>
+          <li><a href="<%= u("/feeds/export") %>"><%= t('layout.export') %></a></li>
           <li class="muted">·</li>
           <li><a href="#shortcuts" data-toggle="modal"><i class="icon-keyboard"></i></a></li>
           <li class="muted">·</li>

--- a/app/views/partials/_mark_all_as_read_form.erb
+++ b/app/views/partials/_mark_all_as_read_form.erb
@@ -1,5 +1,5 @@
 <div class="hide">
-  <form id="mark-all-as-read" method="POST" action="/stories/mark_all_as_read">
+  <form id="mark-all-as-read" method="POST" action="<%= u("/stories/mark_all_as_read") %>">
     <% stories.each do |story| %>
       <input type="hidden" name="story_ids[]" value="<%= story.id %>" />
     <% end %>

--- a/app/views/partials/_single_feed_action_bar.erb
+++ b/app/views/partials/_single_feed_action_bar.erb
@@ -1,6 +1,6 @@
 <div class="row-fluid">
   <div class="pull-left">
-    <a class="btn" id="home" href="<%= url('/news') %>" title="<%= t('partials.feed_action_bar.home') %>">
+    <a class="btn" id="home" href="<%= u('/news') %>" title="<%= t('partials.feed_action_bar.home') %>">
       <i class="icon-reply"></i>
     </a>
     <a class="btn" id="mark-all" title="<%= t('partials.action_bar.mark_all') %>">
@@ -8,22 +8,22 @@
       <%= render_partial :mark_all_as_read_form,
                         {stories: stories} %>
     </a>
-    <a class="btn" href="<%= url("/feed/#{@feed.id}") %>" id="refresh" title="<%= t('partials.action_bar.refresh') %>">
+    <a class="btn" href="<%= u("/feed/#{@feed.id}") %>" id="refresh" title="<%= t('partials.action_bar.refresh') %>">
       <i class="icon-repeat"></i>
     </a>
   </div>
 
   <div class="pull-right">
-    <a class="btn btn-primary" id="starred" href="<%= url('/starred') %>" title="<%= t('partials.action_bar.starred_stories') %>">
+    <a class="btn btn-primary" id="starred" href="<%= u("/starred") %>" title="<%= t('partials.action_bar.starred_stories') %>">
       <i class="icon-star"></i>
     </a>
-    <a class="btn btn-primary" id="archive" href="<%= url('/archive') %>" title="<%= t('partials.action_bar.archived_stories') %>">
+    <a class="btn btn-primary" id="archive" href="<%= u("/archive") %>" title="<%= t('partials.action_bar.archived_stories') %>">
       <i class="icon-time"></i>
     </a>
-    <a class="btn btn-primary" id="feeds" href="<%= url('/feeds') %>" title="<%= t('partials.action_bar.view_feeds') %>">
+    <a class="btn btn-primary" id="feeds" href="<%= u("/feeds") %>" title="<%= t('partials.action_bar.view_feeds') %>">
       <i class="icon-list"></i>
     </a>
-    <a class="btn btn-primary" id="add-feed" href="<%= url('/feeds/new') %>" title="<%= t('partials.action_bar.add_feed') %>">
+    <a class="btn btn-primary" id="add-feed" href="<%= u("/feeds/new") %>" title="<%= t('partials.action_bar.add_feed') %>">
       <i class="icon-plus"></i>
     </a>
   </div>

--- a/app/views/partials/_tutorial_action_bar.erb
+++ b/app/views/partials/_tutorial_action_bar.erb
@@ -5,16 +5,16 @@
       <%= render_partial :mark_all_as_read_form,
                         {stories: stories} %>
     </a>
-    <a class="btn" href="/" id="refresh" title="<%= t('partials.action_bar.refresh') %>">
+    <a class="btn" href="<%= u("/") %>" id="refresh" title="<%= t('partials.action_bar.refresh') %>">
       <i class="icon-repeat"></i>
     </a>
   </div>
 
   <div class="pull-right">
-    <a class="btn btn-primary" id="feeds" href="/feeds" title="<%= t('partials.action_bar.view_feeds') %>">
+    <a class="btn btn-primary" id="feeds" href="<%= u("/feeds") %>" title="<%= t('partials.action_bar.view_feeds') %>">
       <i class="icon-list"></i>
     </a>
-    <a class="btn btn-primary" id="add-feed" href="/feeds/new" title="<%= t('partials.action_bar.add_feed') %>">
+    <a class="btn btn-primary" id="add-feed" href="<%= u("/feeds/new") %>" title="<%= t('partials.action_bar.add_feed') %>">
       <i class="icon-plus"></i>
     </a>
   </div>

--- a/app/views/partials/_zen.erb
+++ b/app/views/partials/_zen.erb
@@ -7,6 +7,6 @@
     </small>
   </p>
   <p class="view-all">
-    <a href="/archive"><%= t('partials.zen.archive') %></a>
+    <a href="<%= u('/archive') %>"><%= t('partials.zen.archive') %></a>
   </p>
 </div>

--- a/app/views/sessions/new.erb
+++ b/app/views/sessions/new.erb
@@ -4,7 +4,7 @@
 
   <hr />
 
-  <form method="POST" id="login" action="/login">
+  <form method="POST" id="login" action="<%= u("/login") %>">
     <input class="hidden" value="username" />
     <div class="control-group">
       <input name="password" id="password" type="password" autofocus="autofocus" />

--- a/app/views/tutorial.erb
+++ b/app/views/tutorial.erb
@@ -36,7 +36,7 @@
   <p id="cta"><%= t('tutorial.description') %></p>
   <hr />
   <div class="center">
-    <a href="/news" id="start" style="display: none" class="btn btn-primary"><%= t('tutorial.start') %></a>
+    <a href="<%= u("/news") %>" id="start" style="display: none" class="btn btn-primary"><%= t('tutorial.start') %></a>
   </div>
 </div>
 


### PR DESCRIPTION
Tested locally with two configurations, mount to / and mount to /rss. I've never programmed in Ruby/Sinatra, I've tried to match the current style (single-letter helper function for templates).

--

From the commit message:

* enable prefixed redirects so all redirects use the local application
* use uri(..., false, true) to handle \<a href="..."\> locations
* make CSS asset references relative

To run Stringer on a different base url (or url prefix), use

```ruby
require "./app"
map "/rss"do
  run Stringer
end
```

in your 'config.ru'.