### PR TITLE
Enable PostgreSQL addon on one-click deploy

### DIFF
--- a/app.json
+++ b/app.json
@@ -22,6 +22,7 @@
     }
   },
   "addons": [
+    "heroku-postgresql:hobby-dev",
     "scheduler:standard"
   ]
 }


### PR DESCRIPTION
Stringer depends on a PostgreSQL database, so enable the hobby-dev (free) version of the addon on one-click deploy.

Ref: #368