### PR TITLE
Fill feed URL field from params

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -31,6 +31,7 @@ class Stringer < Sinatra::Base
   end
 
   get "/feeds/new" do
+    @feed_url = params[:feed_url]
     erb :'feeds/add'
   end
 


### PR DESCRIPTION
Read the feed URL from params on request to `/feeds/new` and let it fill the feed URL field. This enables integration with the [RSS Subscription Extension][rss-subscription-ext] extension for Google Chrome and should allow integration with similar extensions, for Google Chrome or other browsers.

[rss-subscription-ext]: https://chrome.google.com/webstore/detail/rss-subscription-extensio/nlbjncdgjeocebhnmkbbbdekmmmcbfjd