### PR TITLE
use TLS for external resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Stringer
 
-[![Build Status](http://img.shields.io/travis/swanson/stringer.svg?style=flat)](https://travis-ci.org/swanson/stringer)
-[![Code Climate](http://img.shields.io/codeclimate/github/swanson/stringer.svg?style=flat)](https://codeclimate.com/github/swanson/stringer)
-[![Coverage Status](http://img.shields.io/coveralls/swanson/stringer.svg?style=flat)](https://coveralls.io/r/swanson/stringer)
+[![Build Status](https://img.shields.io/travis/swanson/stringer.svg?style=flat)](https://travis-ci.org/swanson/stringer)
+[![Code Climate](https://img.shields.io/codeclimate/github/swanson/stringer.svg?style=flat)](https://codeclimate.com/github/swanson/stringer)
+[![Coverage Status](https://img.shields.io/coveralls/swanson/stringer.svg?style=flat)](https://coveralls.io/r/swanson/stringer)
 
 ### A self-hosted, anti-social RSS reader.
 

--- a/app/utils/sample_story.rb
+++ b/app/utils/sample_story.rb
@@ -12,7 +12,7 @@ class SampleStory < Struct.new(:source, :title, :lead, :is_read, :published)
     tattooed. Keffiyeh mumblecore fingerstache, sartorial sriracha disrupt biodiesel cred. 
     Skateboard yr cosby sweater, narwhal beard ethnic jean shorts aesthetic. Post-ironic 
     flannel mlkshk, pickled VHS wolf banjo forage portland wayfarers.</p>
-    <img src='http://placekitten.com/g/500/300' />
+    <img src='https://placekitten.com/g/500/300' />
     <p>Selfies mumblecore odd future <a href="#">irony DIY messenger bag</a>. Authentic neutra next 
     level selvage squid. Four loko freegan occupy, tousled vinyl leggings selvage messenger 
     bag. Four loko wayfarers kale chips, next level banksy banh mi umami flannel hella. 

--- a/app/views/tutorial.erb
+++ b/app/views/tutorial.erb
@@ -1,5 +1,5 @@
 <% content_for :head do %>
-  <link href='http://fonts.googleapis.com/css?family=Reenie+Beanie' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Reenie+Beanie' rel='stylesheet' type='text/css'>
 <% end %>
 
 <div class="tutorial-overlay">


### PR DESCRIPTION
3 changes, in decreasing order of importance:

* Heroku automatically sends you to the HTTPS version of the app when you install with Heroku Button.
Then, Firefox (since [version 23](https://developer.mozilla.org/en-US/docs/Security/MixedContent/How_to_fix_website_with_mixed_content)) blocks the download of Reenie Beanie, and apparently replaces it with Comic Sans MS?!
* The changes in README.md are mostly irrelevant because of https://help.github.com/articles/why-do-my-images-have-strange-urls/, but it's good practice, in case it ends up getting rendered somewhere that isn't GitHub.
* I'm not sure if the Placekitten one is even viewable from a browser -- I didn't bother checking. The HTTPS version of the resource does load, however, so it probably won't break anything.