### PR TITLE
Enforce SSL by default when using the Heroku button

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,6 +19,10 @@
     "LOCALE": {
       "description": "Specify the translation locale you wish to use",
       "value": "en"
+    },
+    "ENFORCE_SSL": {
+      "description": "Force all clients to connect over SSL",
+      "value": "true"
     }
   },
   "addons": [


### PR DESCRIPTION
> Heroku serves a wildcard *.herokuapp.com certificate, so for most people, HSTS
> should be enabled.

<https://github.com/swanson/stringer/issues/382#issue-100622734>