### PR TITLE
Redirect to the previous page after login

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -91,6 +91,7 @@ class Stringer < Sinatra::Base
     I18n.locale = ENV["LOCALE"].blank? ? :en : ENV["LOCALE"].to_sym
 
     if !is_authenticated? && needs_authentication?(request.path)
+      session[:redirect_to] = request.path
       redirect '/login'
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,11 +10,8 @@ class Stringer < Sinatra::Base
     if user
       session[:user_id] = user.id
 
-      if session[:redirect_to].present?
-        redirect to(session.delete(:redirect_to))
-      else
-        redirect to("/")
-      end
+      redirect_uri = session.delete(:redirect_to) || '/'
+      redirect to(redirect_uri)
     else
       flash.now[:error] = t('sessions.new.flash.wrong_password')
       erb :"sessions/new"

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,7 +10,11 @@ class Stringer < Sinatra::Base
     if user
       session[:user_id] = user.id
 
-      redirect to("/")
+      if session[:redirect_to].present?
+        redirect to(session.delete(:redirect_to))
+      else
+        redirect to("/")
+      end
     else
       flash.now[:error] = t('sessions.new.flash.wrong_password')
       erb :"sessions/new"

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -33,6 +33,16 @@ describe "SessionsController" do
       last_response.status.should be 302
       URI::parse(last_response.location).path.should eq "/"
     end
+
+    it "redirects to the previous path when present" do
+      SignInUser.stub(:sign_in).and_return(double(id: 1))
+
+      post "/login", { password: "the-password" },
+        'rack.session' => { redirect_to: '/archive' }
+
+      session[:redirect_to].should be_nil
+      URI::parse(last_response.location).path.should eq "/archive"
+    end
   end
 
   describe "GET /logout" do


### PR DESCRIPTION
When going to an URL that needs authentication (like `/archive/` or `/feed/:id`) we currently get redirected to the login page and then to the feed index. This redirects to the page we initially tried to access after login.