### PR TITLE
Fix handling of relative entry urls

### DIFF
--- a/app/repositories/story_repository.rb
+++ b/app/repositories/story_repository.rb
@@ -124,8 +124,10 @@ class StoryRepository
     uri      = URI.parse(url)
     base_uri = URI.parse(base_url)
 
-    unless uri.scheme
-      uri.scheme = base_uri.scheme || 'http'
+    # resolve (protocol) relative URIs
+    if uri.relative?
+      scheme = base_uri.scheme || 'http'
+      uri = URI.join("#{scheme}://#{base_uri.host}", uri)
     end
 
     uri.to_s

--- a/spec/repositories/story_repository_spec.rb
+++ b/spec/repositories/story_repository_spec.rb
@@ -153,5 +153,10 @@ describe StoryRepository do
       url = StoryRepository.normalize_url("//blog.golang.org/context", "//blog.golang.org/feed.atom")
       url.should eq 'http://blog.golang.org/context'
     end
+
+    it "resolves relative urls" do
+      url = StoryRepository.normalize_url("/progrium/dokku/releases/tag/v0.4.4", "https://github.com/progrium/dokku/releases.atom")
+      url.should eq "https://github.com/progrium/dokku/releases/tag/v0.4.4"
+    end
   end
 end


### PR DESCRIPTION
Before, normalize_url would completely bork relative urls.

In the example used in the spec the result would be
`https:/progrium/dokku/releases/tag/v0.4.4` which is of course
completely wrong.