### PR TITLE
Fix command that sets APP_URL in Heroku.md

### DIFF
--- a/docs/Heroku.md
+++ b/docs/Heroku.md
@@ -4,7 +4,7 @@ cd stringer
 heroku create
 git push heroku master
 
-heroku config:set APP_URL=`heroku apps:info --shell | grep web_url | cut -d= -f2`
+heroku config:set APP_URL=`heroku apps:info --shell | grep web-url | cut -d= -f2`
 heroku config:set SECRET_TOKEN=`openssl rand -hex 20`
 
 heroku run rake db:migrate


### PR DESCRIPTION
The `heroku apps:info --shell` command outputs the app's URL in an attribute named `web-url`, not `web_url` (with a hyphen, not an underscore).