### PR TITLE
Adds group_id to Feeds#edit

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -18,7 +18,7 @@ class Stringer < Sinatra::Base
   put "/feeds/:id" do
     feed = FeedRepository.fetch(params[:id])
 
-    FeedRepository.update_feed(feed, params[:feed_name], params[:feed_url])
+    FeedRepository.update_feed(feed, params[:feed_name], params[:feed_url], params[:group_id])
 
     flash[:success] = t('feeds.edit.flash.updated_successfully')
     redirect to('/feeds')

--- a/app/public/css/styles.css
+++ b/app/public/css/styles.css
@@ -489,9 +489,17 @@ li.feed .remove-feed a:hover {
   transition: 0.25s;
 }
 
-.setup #password, .setup #password-confirmation, .setup #feed-url, .setup #feed-name {
+.setup #password, .setup #password-confirmation, .setup #feed-url, .setup #feed-name, .setup input.select-dummy {
   padding-left: 100px;
   padding-right: 36px;
+}
+
+.setup select {
+  display: block;
+  position: absolute;
+  left: 100px;
+  top: 5px;
+  width: 244px;
 }
 
 .setup .control-group {

--- a/app/repositories/feed_repository.rb
+++ b/app/repositories/feed_repository.rb
@@ -11,9 +11,10 @@ class FeedRepository
     Feed.where(id: ids)
   end
 
-  def self.update_feed(feed, name, url)
+  def self.update_feed(feed, name, url, group_id = nil)
     feed.name = name
     feed.url = url
+    feed.group_id = group_id
     feed.save
   end
 

--- a/app/views/feeds/edit.erb
+++ b/app/views/feeds/edit.erb
@@ -18,6 +18,18 @@
         <i class="icon-rss field-icon"></i>
         <label id="feed_url-label" class="field-label" for="feed_url"><%= t('feeds.edit.fields.feed_url') %></label>
       </div>
+      <% if Group.any? %>
+        <div class="control-group">
+          <input type="text" class="select-dummy" tabindex="-1">
+          <select name="group_id" id="group-id">
+            <option value=""></option>
+            <% Group.all.each do |group| %>
+              <option value="<%= group.id %>" <%= "selected" if @feed.group_id == group.id %>><%= group.name %></option>
+            <% end %>
+          </select>
+          <label id="group_id-label" class="field-label" for="group_id"><%= t('feeds.edit.fields.group') %></label>
+        </div>
+      <% end %>
 
     <input type="submit" id="submit" class="btn btn-primary pull-right" value="<%= t('feeds.edit.fields.submit') %>"/>
   </form>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
       fields:
         feed_name: Feed Name
         feed_url: Feed URL
+        group: Group
         submit: Save
       flash:
         updated_successfully: Updated the feed for ya'!

--- a/spec/controllers/feeds_controller_spec.rb
+++ b/spec/controllers/feeds_controller_spec.rb
@@ -42,9 +42,19 @@ describe "FeedsController" do
     it "updates a feed given the id" do
       feed = FeedFactory.build(url: 'example.com/atom')
       FeedRepository.should_receive(:fetch).with("123").and_return(feed)
-      FeedRepository.should_receive(:update_feed).with(feed, 'Test', 'example.com/feed')
+      FeedRepository.should_receive(:update_feed).with(feed, 'Test', 'example.com/feed', nil)
 
       put "/feeds/123", feed_id: "123", feed_name: "Test", feed_url: "example.com/feed"
+
+      last_response.should be_redirect
+    end
+
+    it "updates a feed group given the id" do
+      feed = FeedFactory.build(url: 'example.com/atom')
+      FeedRepository.should_receive(:fetch).with("123").and_return(feed)
+      FeedRepository.should_receive(:update_feed).with(feed, feed.name, feed.url, "321")
+
+      put "/feeds/123", feed_id: "123", feed_name: feed.name, feed_url: feed.url, group_id: "321"
 
       last_response.should be_redirect
     end


### PR DESCRIPTION
I've been using groups for quite a while. While this is a hidden feature it would be handy that feeds could be linked using the interface. The dropdown will only be shown when there are any groups so that people not using the feature don't get confused about it.

I might also look into more group management later on, but I rarely use the web interface so it's not really a priority for me right now. (and I've got a lot of other stuff on my plate)

The only think that needs to be fixed is the design of the dropdown. I guess stringer is a custom theme? Would any of you mind to help me fix it? I'll try to fix it myself but it might take a few days/weeks.

<img width="410" alt="screen shot 2015-12-18 at 22 03 20" src="https://cloud.githubusercontent.com/assets/76424/11907318/3b56002c-a5d3-11e5-94a2-46f945d4c8cc.png">
