### PR TITLE
Fix RuboCop metrics offences

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,12 @@ AllCops:
   Exclude:
     - 'db/schema.rb'
     - 'vendor/**/*'
+
+Metrics/LineLength:
+  Max: 120
+
+Style/IfUnlessModifier:
+  MaxLineLength: 120
+
+Style/WhileUntilModifier:
+  MaxLineLength: 120

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,9 @@ AllCops:
 Metrics/LineLength:
   Max: 120
 
+Metrics/MethodLength:
+  Max: 15
+
 Style/IfUnlessModifier:
   MaxLineLength: 120
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,11 +11,6 @@
 Metrics/ClassLength:
   Max: 108
 
-# Offense count: 131
-# Configuration parameters: AllowURI, URISchemes.
-Metrics/LineLength:
-  Max: 352
-
 # Offense count: 11
 # Configuration parameters: CountComments.
 Metrics/MethodLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,11 +11,6 @@
 Metrics/ClassLength:
   Max: 108
 
-# Offense count: 11
-# Configuration parameters: CountComments.
-Metrics/MethodLength:
-  Max: 22
-
 # Offense count: 2
 Metrics/PerceivedComplexity:
   Max: 9

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,10 +11,6 @@
 Metrics/ClassLength:
   Max: 108
 
-# Offense count: 2
-Metrics/PerceivedComplexity:
-  Max: 9
-
 # Offense count: 14
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedHashRocketStyle, EnforcedColonStyle, EnforcedLastArgumentHashStyle, SupportedLastArgumentHashStyles.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,11 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-# Configuration parameters: CountComments.
-Metrics/ClassLength:
-  Max: 108
-
 # Offense count: 14
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedHashRocketStyle, EnforcedColonStyle, EnforcedLastArgumentHashStyle, SupportedLastArgumentHashStyles.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -11,10 +11,6 @@
 Metrics/ClassLength:
   Max: 108
 
-# Offense count: 2
-Metrics/CyclomaticComplexity:
-  Max: 9
-
 # Offense count: 131
 # Configuration parameters: AllowURI, URISchemes.
 Metrics/LineLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,10 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 5
-Metrics/AbcSize:
-  Max: 37
-
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:

--- a/app/commands/feeds/export_to_opml.rb
+++ b/app/commands/feeds/export_to_opml.rb
@@ -5,7 +5,7 @@ class ExportToOpml
     @feeds = feeds
   end
 
-  def to_xml
+  def to_xml # rubocop:disable Metrics/MethodLength
     builder = Nokogiri::XML::Builder.new do |xml|
       xml.opml(version: "1.0") do
         xml.head {

--- a/app/commands/feeds/find_new_stories.rb
+++ b/app/commands/feeds/find_new_stories.rb
@@ -15,10 +15,8 @@ class FindNewStories
 
     @raw_feed.entries.each do |story|
       break if @latest_entry_id && story.id == @latest_entry_id
-
-      unless story_age_exceeds_threshold?(story) || StoryRepository.exists?(story.id, @feed_id)
-        stories << story
-      end
+      next if story_age_exceeds_threshold?(story) || StoryRepository.exists?(story.id, @feed_id)
+      stories << story
     end
 
     stories

--- a/app/fever_api/response.rb
+++ b/app/fever_api/response.rb
@@ -16,28 +16,33 @@ require_relative "write_mark_group"
 
 module FeverAPI
   class Response
+    ACTIONS = [
+      Authentication,
+
+      ReadFeeds,
+      ReadGroups,
+      ReadFeedsGroups,
+      ReadFavicons,
+      ReadItems,
+      ReadLinks,
+
+      SyncUnreadItemIds,
+      SyncSavedItemIds,
+
+      WriteMarkItem,
+      WriteMarkFeed,
+      WriteMarkGroup
+    ]
+
     def initialize(params)
-      @response = { api_version: 3 }
-
-      @response.merge! Authentication.new.call(params)
-
-      @response.merge! ReadFeeds.new.call(params)
-      @response.merge! ReadGroups.new.call(params)
-      @response.merge! ReadFeedsGroups.new.call(params)
-      @response.merge! ReadFavicons.new.call(params)
-      @response.merge! ReadItems.new.call(params)
-      @response.merge! ReadLinks.new.call(params)
-
-      @response.merge! SyncUnreadItemIds.new.call(params)
-      @response.merge! SyncSavedItemIds.new.call(params)
-
-      @response.merge! WriteMarkItem.new.call(params)
-      @response.merge! WriteMarkFeed.new.call(params)
-      @response.merge! WriteMarkGroup.new.call(params)
+      @params = params
     end
 
     def to_json
-      @response.to_json
+      base_response = { api_version: 3 }
+      ACTIONS
+        .inject(base_response) { |a, e| a.merge!(e.new.call(@params)) }
+        .to_json
     end
   end
 end

--- a/app/fever_api/write_mark_feed.rb
+++ b/app/fever_api/write_mark_feed.rb
@@ -7,9 +7,7 @@ module FeverAPI
     end
 
     def call(params = {})
-      if params[:mark] == "feed"
-        @marker_class.new(params[:id], params[:before]).mark_feed_as_read
-      end
+      @marker_class.new(params[:id], params[:before]).mark_feed_as_read if params[:mark] == "feed"
 
       {}
     end

--- a/app/fever_api/write_mark_group.rb
+++ b/app/fever_api/write_mark_group.rb
@@ -7,9 +7,7 @@ module FeverAPI
     end
 
     def call(params = {})
-      if params[:mark] == "group"
-        @marker_class.new(params[:id], params[:before]).mark_group_as_read
-      end
+      @marker_class.new(params[:id], params[:before]).mark_group_as_read if params[:mark] == "group"
 
       {}
     end

--- a/app/fever_api/write_mark_item.rb
+++ b/app/fever_api/write_mark_item.rb
@@ -13,20 +13,24 @@ module FeverAPI
     end
 
     def call(params = {})
-      if params[:mark] == "item"
-        case params[:as]
-        when "read"
-          @read_marker_class.new(params[:id]).mark_as_read
-        when "unread"
-          @unread_marker_class.new(params[:id]).mark_as_unread
-        when "saved"
-          @starred_marker_class.new(params[:id]).mark_as_starred
-        when "unsaved"
-          @unstarred_marker_class.new(params[:id]).mark_as_unstarred
-        end
-      end
+      mark_item_as(params[:id], params[:as]) if params[:mark] == "item"
 
       {}
+    end
+
+    private
+
+    def mark_item_as(id, as)
+      case as
+      when "read"
+        @read_marker_class.new(id).mark_as_read
+      when "unread"
+        @unread_marker_class.new(id).mark_as_unread
+      when "saved"
+        @starred_marker_class.new(id).mark_as_starred
+      when "unsaved"
+        @unstarred_marker_class.new(id).mark_as_unstarred
+      end
     end
   end
 end

--- a/app/helpers/authentication_helpers.rb
+++ b/app/helpers/authentication_helpers.rb
@@ -11,9 +11,8 @@ module Sinatra
     def needs_authentication?(path)
       return false if ENV['RACK_ENV'] == 'test'
       return false if !UserRepository.setup_complete?
-      return false if path == "/login" || path == "/logout"
-      return false if path =~ /css/ || path =~ /js/ || path =~ /img/
-      return false if path == "/heroku"
+      return false if %w(/login /logout /heroku).include?(path)
+      return false if path =~ /css|js|img/
       true
     end
 

--- a/app/helpers/url_helpers.rb
+++ b/app/helpers/url_helpers.rb
@@ -1,0 +1,39 @@
+require "nokogiri"
+require "uri"
+
+module UrlHelpers
+  ABS_RE = URI::DEFAULT_PARSER.regexp[:ABS_URI]
+
+  def expand_absolute_urls(content, base_url)
+    doc = Nokogiri::HTML.fragment(content)
+
+    [["a", "href"], ["img", "src"], ["video", "src"]].each do |tag, attr|
+      doc.css("#{tag}[#{attr}]").each do |node|
+        url = node.get_attribute(attr)
+        next if url =~ ABS_RE
+
+        begin
+          node.set_attribute(attr, URI.join(base_url, url).to_s)
+        rescue URI::InvalidURIError # rubocop:disable Lint/HandleExceptions
+          # Just ignore. If we cannot parse the url, we don't want the entire
+          # import to blow up.
+        end
+      end
+    end
+
+    doc.to_html
+  end
+
+  def normalize_url(url, base_url)
+    uri = URI.parse(url)
+
+    # resolve (protocol) relative URIs
+    if uri.relative?
+      base_uri = URI.parse(base_url)
+      scheme = base_uri.scheme || 'http'
+      uri = URI.join("#{scheme}://#{base_uri.host}", uri)
+    end
+
+    uri.to_s
+  end
+end

--- a/app/tasks/fetch_feed.rb
+++ b/app/tasks/fetch_feed.rb
@@ -18,13 +18,9 @@ class FetchFeed
       raw_feed = fetch_raw_feed
 
       if raw_feed == 304
-        @logger.info "#{@feed.url} has not been modified since last fetch" if @logger
+        feed_not_modified
       else
-        new_entries_from(raw_feed).each do |entry|
-          StoryRepository.add(entry, @feed)
-        end
-
-        FeedRepository.update_last_fetched(@feed, raw_feed.last_modified)
+        feed_modified(raw_feed)
       end
 
       FeedRepository.set_status(:green, @feed)
@@ -39,6 +35,18 @@ class FetchFeed
 
   def fetch_raw_feed
     @parser.fetch_and_parse(@feed.url, options)
+  end
+
+  def feed_not_modified
+    @logger.info "#{@feed.url} has not been modified since last fetch" if @logger
+  end
+
+  def feed_modified(raw_feed)
+    new_entries_from(raw_feed).each do |entry|
+      StoryRepository.add(entry, @feed)
+    end
+
+    FeedRepository.update_last_fetched(@feed, raw_feed.last_modified)
   end
 
   def new_entries_from(raw_feed)

--- a/app/tasks/fetch_feed.rb
+++ b/app/tasks/fetch_feed.rb
@@ -15,15 +15,7 @@ class FetchFeed
 
   def fetch
     begin
-      options = {
-        user_agent: USER_AGENT,
-        if_modified_since: @feed.last_fetched,
-        timeout: 30,
-        max_redirects: 2,
-        compress: true
-      }
-
-      raw_feed = @parser.fetch_and_parse(@feed.url, options)
+      raw_feed = fetch_raw_feed
 
       if raw_feed == 304
         @logger.info "#{@feed.url} has not been modified since last fetch" if @logger
@@ -44,9 +36,24 @@ class FetchFeed
   end
 
   private
+
+  def fetch_raw_feed
+    @parser.fetch_and_parse(@feed.url, options)
+  end
+
   def new_entries_from(raw_feed)
     finder = FindNewStories.new(raw_feed, @feed.id, @feed.last_fetched, latest_entry_id)
     finder.new_stories
+  end
+
+  def options
+    {
+      user_agent: USER_AGENT,
+      if_modified_since: @feed.last_fetched,
+      timeout: 30,
+      max_redirects: 2,
+      compress: true
+    }
   end
 
   def latest_entry_id

--- a/app/utils/opml_parser.rb
+++ b/app/utils/opml_parser.rb
@@ -2,13 +2,10 @@ require "nokogiri"
 
 class OpmlParser
   def parse_feeds(contents)
-    doc = Nokogiri.XML(contents)
-
     feeds_with_groups = Hash.new { |h, k| h[k] = [] }
 
-    doc.xpath('//body/outline').each do |outline|
-
-      if outline.attributes['xmlUrl'].nil? # it's a group!
+    outlines_in(contents).each do |outline|
+      if outline_is_group?(outline)
         group_name = extract_name(outline.attributes).value
         feeds = outline.xpath('./outline')
       else # it's a top-level feed, which means it's a feed without group
@@ -17,16 +14,31 @@ class OpmlParser
       end
 
       feeds.each do |feed|
-        feeds_with_groups[group_name] << { name: extract_name(feed.attributes).value,
-                                           url:  feed.attributes['xmlUrl'].value }
+        feeds_with_groups[group_name] << feed_to_hash(feed)
       end
     end
+
     feeds_with_groups
   end
 
   private
 
+  def outlines_in(contents)
+    Nokogiri.XML(contents).xpath('//body/outline')
+  end
+
+  def outline_is_group?(outline)
+    outline.attributes['xmlUrl'].nil?
+  end
+
   def extract_name(attributes)
     attributes['title'] || attributes['text']
+  end
+
+  def feed_to_hash(feed)
+    {
+      name: extract_name(feed.attributes).value,
+      url:  feed.attributes['xmlUrl'].value
+    }
   end
 end

--- a/app/utils/sample_story.rb
+++ b/app/utils/sample_story.rb
@@ -1,28 +1,32 @@
 class SampleStory < Struct.new(:source, :title, :lead, :is_read, :published)
+  BODY = <<-eos
+<p>Tofu shoreditch intelligentsia <a href="#">umami</a>, fashion axe photo booth
+try-hard terry richardson quinoa actually fingerstache meggings fixie. Aesthetic
+salvia vinyl raw denim, keffiyeh master cleanse tonx selfies mlkshk occupy twee
+street art gentrify. Quinoa PBR readymade 90's. <b>Chambray</b> Austin aesthetic
+meggings, carles vinyl intelligentsia tattooed. Keffiyeh mumblecore
+fingerstache, sartorial sriracha disrupt biodiesel cred. Skateboard yr cosby
+sweater, narwhal beard ethnic jean shorts aesthetic. Post-ironic flannel mlkshk,
+pickled VHS wolf banjo forage portland wayfarers.</p>
+<img src='https://placekitten.com/g/500/300' />
+<p>Selfies mumblecore odd future <a href="#">irony DIY messenger bag</a>.
+Authentic neutra next level selvage squid. Four loko freegan occupy, tousled
+vinyl leggings selvage messenger bag. Four loko wayfarers kale chips, next level
+banksy banh mi umami flannel hella. Street art odd future scenester,
+intelligentsia brunch fingerstache YOLO narwhal single-origin coffee tousled
+tumblr pop-up four loko you probably haven't heard of them dreamcatcher.
+Single-origin coffee direct trade retro biodiesel, truffaut fanny pack portland
+blue bottle scenester bushwick. Skateboard squid fanny pack bushwick, photo
+booth vice literally.</p>
+    eos
+
   def id; -1 * rand(100); end
   def headline; title; end
   def permalink; "#"; end
-  def lead; "Tofu shoreditch intelligentsia umami, fashion axe photo booth try-hard"; end
-  def body
-    <<-eos
-    <p>Tofu shoreditch intelligentsia <a href="#">umami</a>, fashion axe photo booth try-hard terry
-    richardson quinoa actually fingerstache meggings fixie. Aesthetic salvia vinyl raw
-    denim, keffiyeh master cleanse tonx selfies mlkshk occupy twee street art gentrify.
-    Quinoa PBR readymade 90's. <b>Chambray</b> Austin aesthetic meggings, carles vinyl intelligentsia
-    tattooed. Keffiyeh mumblecore fingerstache, sartorial sriracha disrupt biodiesel cred.
-    Skateboard yr cosby sweater, narwhal beard ethnic jean shorts aesthetic. Post-ironic
-    flannel mlkshk, pickled VHS wolf banjo forage portland wayfarers.</p>
-    <img src='https://placekitten.com/g/500/300' />
-    <p>Selfies mumblecore odd future <a href="#">irony DIY messenger bag</a>. Authentic neutra next
-    level selvage squid. Four loko freegan occupy, tousled vinyl leggings selvage messenger
-    bag. Four loko wayfarers kale chips, next level banksy banh mi umami flannel hella.
-    Street art odd future scenester, intelligentsia brunch fingerstache YOLO narwhal
-    single-origin coffee tousled tumblr pop-up four loko you probably haven't heard of them
-    dreamcatcher. Single-origin coffee direct trade retro biodiesel, truffaut fanny pack
-    portland blue bottle scenester bushwick. Skateboard squid fanny pack bushwick, photo
-    booth vice literally.</p>
-eos
+  def lead
+    "Tofu shoreditch intelligentsia umami, fashion axe photo booth try-hard"
   end
+  def body; BODY; end
   def is_read; false; end
   def keep_unread; false; end
   def is_starred; false; end

--- a/db/migrate/20130425222157_add_delayed_job.rb
+++ b/db/migrate/20130425222157_add_delayed_job.rb
@@ -1,19 +1,39 @@
 class AddDelayedJob < ActiveRecord::Migration
   def self.up
-    create_table :delayed_jobs, :force => true do |table|
-      table.integer  :priority, :default => 0      # Allows some jobs to jump to the front of the queue
-      table.integer  :attempts, :default => 0      # Provides for retries, but still fail eventually.
-      table.text     :handler                      # YAML-encoded string of the object that will do work
-      table.text     :last_error                   # reason for last failure (See Note below)
-      table.datetime :run_at                       # When to run. Could be Time.zone.now for immediately, or sometime in the future.
-      table.datetime :locked_at                    # Set when a client is working on this object
-      table.datetime :failed_at                    # Set when all retries have failed (actually, by default, the record is deleted instead)
-      table.string   :locked_by                    # Who is working on this object (if locked)
-      table.string   :queue                        # The name of the queue this job is in
+    create_table :delayed_jobs, force: true do |table|
+      # Allows some jobs to jump to the front of the queue
+      table.integer  :priority, default: 0
+
+      # Provides for retries, but still fail eventually.
+      table.integer  :attempts, default: 0
+
+      # YAML-encoded string of the object that will do work
+      table.text     :handler
+
+      # reason for last failure (See Note below)
+      table.text     :last_error
+
+      # When to run. Could be Time.zone.now for immediately, or sometime in the
+      # future.
+      table.datetime :run_at
+
+      # Set when a client is working on this object
+      table.datetime :locked_at
+
+      # Set when all retries have failed (actually, by default, the record is
+      # deleted instead)
+      table.datetime :failed_at
+
+      # Who is working on this object (if locked)
+      table.string   :locked_by
+
+      # The name of the queue this job is in
+      table.string   :queue
+
       table.timestamps
     end
 
-    add_index :delayed_jobs, [:priority, :run_at], :name => 'delayed_jobs_priority'
+    add_index :delayed_jobs, [:priority, :run_at], name: 'delayed_jobs_priority'
   end
 
   def self.down

--- a/spec/factories/story_factory.rb
+++ b/spec/factories/story_factory.rb
@@ -26,14 +26,16 @@ class StoryFactory
   end
 
   def self.build(params = {})
-    FakeStory.new(
+    default_params = {
       id: rand(100),
-      title: params[:title] || Faker::Lorem.sentence,
-      permalink: params[:permalink] || Faker::Internet.url,
-      body: params[:body] || Faker::Lorem.paragraph,
-      feed: params[:feed] || FeedFactory.build,
-      is_read: params[:is_read] || false,
-      is_starred: params[:is_starred] || false,
-      published: params[:published] || Time.now)
+      title: Faker::Lorem.sentence,
+      permalink: Faker::Internet.url,
+      body: Faker::Lorem.paragraph,
+      feed: FeedFactory.build,
+      is_read: false,
+      is_starred: false,
+      published: Time.now
+    }
+    FakeStory.new(default_params.merge(params))
   end
 end

--- a/spec/helpers/authentications_helper_spec.rb
+++ b/spec/helpers/authentications_helper_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+
+app_require "helpers/authentication_helpers"
+
+RSpec.describe Sinatra::AuthenticationHelpers do
+  class Helper
+    include Sinatra::AuthenticationHelpers
+  end
+
+  let(:helper) { Helper.new }
+
+  describe "#needs_authentication?" do
+    let(:authenticated_path) { "/news" }
+
+    before do
+      stub_const("ENV", "RACK_ENV" => "not-test")
+      allow(UserRepository).to receive(:setup_complete?).and_return(true)
+    end
+
+    context "when `RACK_ENV` is 'test'" do
+      it "returns false" do
+        stub_const("ENV", "RACK_ENV" => "test")
+
+        expect(helper.needs_authentication?(authenticated_path)).to eq(false)
+      end
+    end
+
+    context "when setup in not complete" do
+      it "returns false" do
+        allow(UserRepository).to receive(:setup_complete?).and_return(false)
+
+        expect(helper.needs_authentication?(authenticated_path)).to eq(false)
+      end
+    end
+
+    %w(/login /logout /heroku).each do |path|
+      context "when `path` is '#{path}'" do
+        it "returns false" do
+          expect(helper.needs_authentication?(path)).to eq(false)
+        end
+      end
+    end
+
+    %w(css js img).each do |path|
+      context "when `path` contains '#{path}'" do
+        it "returns false" do
+          expect(helper.needs_authentication?("/#{path}/file.ext")).to eq(false)
+        end
+      end
+    end
+
+    context "otherwise" do
+      it "returns true" do
+        expect(helper.needs_authentication?(authenticated_path)).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/helpers/url_helers_spec.rb
+++ b/spec/helpers/url_helers_spec.rb
@@ -1,0 +1,112 @@
+require "spec_helper"
+
+app_require "helpers/url_helpers"
+
+RSpec.describe UrlHelpers do
+  class Helper
+    include UrlHelpers
+  end
+
+  let(:helper) { Helper.new }
+
+  describe "#expand_absolute_urls" do
+    it "preserves existing absolute urls" do
+      content = '<a href="http://foo">bar</a>'
+
+      helper.expand_absolute_urls(content, nil).should eq content
+    end
+
+    it "replaces relative urls in a, img and video tags" do
+      content = <<-EOS
+<div>
+<img src="https://foo">
+<a href="/bar/baz">tee</a><img src="bar/bar">
+<video src="/tee"></video>
+</div>
+      EOS
+
+      result = helper.expand_absolute_urls(content, "http://oodl.io/d/")
+      result.gsub(/\n/, "").should eq <<-EOS.gsub(/\n/, "")
+<div>
+<img src="https://foo">
+<a href="http://oodl.io/bar/baz">tee</a>
+<img src="http://oodl.io/d/bar/bar">
+<video src="http://oodl.io/tee"></video>
+</div>
+      EOS
+    end
+
+    it "handles empty body" do
+      helper.expand_absolute_urls("", nil).should eq ""
+    end
+
+    it "doesn't modify tags that do not have url attributes" do
+      content = <<-EOS
+<div>
+<img foo="bar">
+<a name="something"/></a>
+<video foo="bar"></video>
+</div>
+      EOS
+
+      result = helper.expand_absolute_urls(content, "http://oodl.io/d/")
+      result.gsub(/\n/, "").should eq <<-EOS.gsub(/\n/, "")
+<div>
+<img foo="bar">
+<a name="something"></a>
+<video foo="bar"></video>
+</div>
+      EOS
+    end
+
+    it "leaves the url as-is if it cannot be parsed" do
+      weird_url = "https://github.com/aphyr/jepsen/blob/" \
+        "1403f2d6e61c595bafede0d404fd4a893371c036/" \
+        "elasticsearch/src/jepsen/system/elasticsearch.clj#" \
+        "L161-L226.%20Then%20we'll%20write%20a%20%5Bregister%20test%5D(" \
+        "https://github.com/aphyr/jepsen/blob/" \
+        "1403f2d6e61c595bafede0d404fd4a893371c036/" \
+        "elasticsearch/test/jepsen/system/elasticsearch_test.clj#L18-L50)"
+
+      content = "<a href=\"#{weird_url}\"></a>"
+
+      result = helper.expand_absolute_urls(content, "http://oodl.io/d/")
+      result.should include(weird_url)
+    end
+  end
+
+  describe "#normalize_url" do
+    it "resolves scheme-less urls" do
+      %w(http https).each do |scheme|
+        feed_url = "#{scheme}://blog.golang.org/feed.atom"
+
+        url = helper.normalize_url("//blog.golang.org/context", feed_url)
+
+        url.should eq "#{scheme}://blog.golang.org/context"
+      end
+    end
+
+    it "leaves urls with a scheme intact" do
+      input = 'http://blog.golang.org/context'
+      normalized_url = helper.normalize_url(
+        input, 'http://blog.golang.org/feed.atom'
+      )
+      normalized_url.should eq(input)
+    end
+
+    it "falls back to http if the base_url is also sheme less" do
+      url = helper.normalize_url(
+        "//blog.golang.org/context", "//blog.golang.org/feed.atom"
+      )
+      url.should eq 'http://blog.golang.org/context'
+    end
+
+    it "resolves relative urls" do
+      url = helper.normalize_url(
+        "/progrium/dokku/releases/tag/v0.4.4",
+        "https://github.com/progrium/dokku/releases.atom"
+      )
+      url.should eq "https://github.com/progrium/dokku/releases/tag/v0.4.4"
+    end
+  end
+end

--- a/spec/repositories/story_repository_spec.rb
+++ b/spec/repositories/story_repository_spec.rb
@@ -77,7 +77,11 @@ describe StoryRepository do
     end
 
     it "leaves the url as-is if it cannot be parsed" do
-      weird_url = "https://github.com/aphyr/jepsen/blob/1403f2d6e61c595bafede0d404fd4a893371c036/elasticsearch/src/jepsen/system/elasticsearch.clj#L161-L226.%20Then%20we'll%20write%20a%20%5Bregister%20test%5D(https://github.com/aphyr/jepsen/blob/1403f2d6e61c595bafede0d404fd4a893371c036/elasticsearch/test/jepsen/system/elasticsearch_test.clj#L18-L50)"
+      weird_url = "https://github.com/aphyr/jepsen/blob/1403f2d6e61c595bafede0d404fd4a893371c036/" \
+        "elasticsearch/src/jepsen/system/elasticsearch.clj" \
+        "#L161-L226.%20Then%20we'll%20write%20a%20%5Bregister%20test%5D" \
+        "(https://github.com/aphyr/jepsen/blob/1403f2d6e61c595bafede0d404fd4a893371c036/" \
+        "elasticsearch/test/jepsen/system/elasticsearch_test.clj#L18-L50)"
 
       content = <<-EOS
       <a href="#{weird_url}"></a>
@@ -155,7 +159,9 @@ describe StoryRepository do
     end
 
     it "resolves relative urls" do
-      url = StoryRepository.normalize_url("/progrium/dokku/releases/tag/v0.4.4", "https://github.com/progrium/dokku/releases.atom")
+      url = StoryRepository.normalize_url(
+        "/progrium/dokku/releases/tag/v0.4.4", "https://github.com/progrium/dokku/releases.atom"
+      )
       url.should eq "https://github.com/progrium/dokku/releases/tag/v0.4.4"
     end
   end

--- a/spec/repositories/story_repository_spec.rb
+++ b/spec/repositories/story_repository_spec.rb
@@ -26,72 +26,6 @@ describe StoryRepository do
     end
   end
 
-  describe ".expand_absolute_urls" do
-    it "preserves existing absolute urls" do
-      content = '<a href="http://foo">bar</a>'
-
-      StoryRepository.expand_absolute_urls(content, nil).should eq content
-    end
-
-    it "replaces relative urls in a, img and video tags" do
-      content = <<-EOS
-<div>
-<img src="https://foo">
-<a href="/bar/baz">tee</a><img src="bar/bar">
-<video src="/tee"></video>
-</div>
-      EOS
-
-      result = StoryRepository.expand_absolute_urls(content, "http://oodl.io/d/")
-      result.gsub(/\n/, "").should eq <<-EOS.gsub(/\n/, "")
-<div>
-<img src="https://foo">
-<a href="http://oodl.io/bar/baz">tee</a>
-<img src="http://oodl.io/d/bar/bar">
-<video src="http://oodl.io/tee"></video>
-</div>
-      EOS
-    end
-
-    it "handles empty body" do
-      StoryRepository.expand_absolute_urls("", nil).should eq ""
-    end
-
-    it "doesn't modify tags that do not have url attributes" do
-      content = <<-EOS
-<div>
-<img foo="bar">
-<a name="something"/></a>
-<video foo="bar"></video>
-</div>
-      EOS
-
-      result = StoryRepository.expand_absolute_urls(content, "http://oodl.io/d/")
-      result.gsub(/\n/, "").should eq <<-EOS.gsub(/\n/, "")
-<div>
-<img foo="bar">
-<a name="something"></a>
-<video foo="bar"></video>
-</div>
-      EOS
-    end
-
-    it "leaves the url as-is if it cannot be parsed" do
-      weird_url = "https://github.com/aphyr/jepsen/blob/1403f2d6e61c595bafede0d404fd4a893371c036/" \
-        "elasticsearch/src/jepsen/system/elasticsearch.clj" \
-        "#L161-L226.%20Then%20we'll%20write%20a%20%5Bregister%20test%5D" \
-        "(https://github.com/aphyr/jepsen/blob/1403f2d6e61c595bafede0d404fd4a893371c036/" \
-        "elasticsearch/test/jepsen/system/elasticsearch_test.clj#L18-L50)"
-
-      content = <<-EOS
-      <a href="#{weird_url}"></a>
-      EOS
-
-      result = StoryRepository.expand_absolute_urls(content, "http://oodl.io/d/")
-      result.should include(weird_url)
-    end
-  end
-
   describe ".extract_content" do
     let(:entry) do
       double(url: "http://mdswanson.com",
@@ -134,35 +68,6 @@ describe StoryRepository do
         result = StoryRepository.sanitize("test\r\ncase")
         result.should eq "test\r\ncase"
       end
-    end
-  end
-
-  describe ".normalize_url" do
-    it "resolves scheme-less urls" do
-      %w{http https}.each do |scheme|
-        feed_url = "#{scheme}://blog.golang.org/feed.atom"
-
-        url = StoryRepository.normalize_url("//blog.golang.org/context", feed_url)
-        url.should eq "#{scheme}://blog.golang.org/context"
-      end
-    end
-
-    it "leaves urls with a scheme intact" do
-      input = 'http://blog.golang.org/context'
-      normalized_url = StoryRepository.normalize_url(input, 'http://blog.golang.org/feed.atom')
-      normalized_url.should eq(input)
-    end
-
-    it "falls back to http if the base_url is also sheme less" do
-      url = StoryRepository.normalize_url("//blog.golang.org/context", "//blog.golang.org/feed.atom")
-      url.should eq 'http://blog.golang.org/context'
-    end
-
-    it "resolves relative urls" do
-      url = StoryRepository.normalize_url(
-        "/progrium/dokku/releases/tag/v0.4.4", "https://github.com/progrium/dokku/releases.atom"
-      )
-      url.should eq "https://github.com/progrium/dokku/releases/tag/v0.4.4"
     end
   end
 end


### PR DESCRIPTION
* Fix Metrics/AbcSize

  ...through some light refactorings.

* Fix Metrics/CyclomaticComplexity

  ...through a small refactoring of `Sinatra::AuthenticationHelpers#needs_authentication?`.

* Set Metrics/LineLength maximum to 120 characters

  Matt and I agreed that 120 characters is a sensible maximum line length for modern editors, see
<https://github.com/swanson/stringer/pull/395#issuecomment-166069080>.

  Also set the `MaxLineLength` option for two other cops, since they're related.

  Joins lines in the Fever API files to fix warnings from `Style/IfUnlessModifier`.

* Lower Metrics/MethodLength maximum to 15 lines

  Despite my best efforts, I find it hard to keep all methods below or at the default maximum length of 10 lines. 15 lines is a somewhat arbitrary compromise that's subject to future tweaking.

  See also: <https://robots.thoughtbot.com/sandi-metz-rules-for-developers>

* Fix Metrics/PerceivedComplexity

* Fix Metrics/ClassLength

  Fixes Metrics/ClassLength by extracting `StoryRepository#expand_absolute_urls` and `StoryRepository#normalize_url` to a separate helper module.