### PR TITLE
Fix RuboCop performance offences

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -33,13 +33,6 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Max: 9
 
-# Offense count: 4
-# Cop supports --auto-correct.
-Performance/StringReplacement:
-  Exclude:
-    - 'db/migrate/20140421224454_fix_invalid_unicode.rb'
-    - 'db/migrate/20141102103617_fix_invalid_titles_with_unicode_line_endings.rb'
-
 # Offense count: 14
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedHashRocketStyle, EnforcedColonStyle, EnforcedLastArgumentHashStyle, SupportedLastArgumentHashStyles.

--- a/db/migrate/20140421224454_fix_invalid_unicode.rb
+++ b/db/migrate/20140421224454_fix_invalid_unicode.rb
@@ -1,7 +1,7 @@
 class FixInvalidUnicode < ActiveRecord::Migration
   def up
     Story.find_each do |story|
-      valid_body = story.body.gsub("\u2028", '').gsub("\u2029", '')
+      valid_body = story.body.delete("\u2028").delete("\u2029")
       story.update_attribute(:body, valid_body)
     end
   end

--- a/db/migrate/20141102103617_fix_invalid_titles_with_unicode_line_endings.rb
+++ b/db/migrate/20141102103617_fix_invalid_titles_with_unicode_line_endings.rb
@@ -2,7 +2,7 @@ class FixInvalidTitlesWithUnicodeLineEndings < ActiveRecord::Migration
   def up
     Story.find_each do |story|
       unless story.title.nil?
-        valid_title = story.title.gsub("\u2028", '').gsub("\u2029", '')
+        valid_title = story.title.delete("\u2028").delete("\u2029")
         story.update_attribute(:title, valid_title)
       end
     end


### PR DESCRIPTION
* Fix Performance/StringReplacement

  > ### delete([other_str]+) -> new_str
  >
  > Returns a copy of *str* with all characters in the intersection of its
  > arguments deleted. Uses the same rules for building the set of characters as
  > `String#count`.

  See <http://ruby-doc.org/core-2.0.0/String.html#method-i-delete>.