### PR TITLE
Fix outdated documentation

### DIFF
--- a/docs/OpenShift.md
+++ b/docs/OpenShift.md
@@ -62,11 +62,13 @@ Deploying into OpenShift
 
  ```
 	gem "coveralls", "~> 0.7", require: false
+	gem "rubocop", "~> 0.35.1", require: false
 	gem "sinatra-assetpack", "~> 0.3.1", require: "sinatra/assetpack"
  ```
 	to
  ```
 	gem "coveralls", "~> 0.7", :require => false
+	gem "rubocop", "~> 0.35.1", :require => false
 	gem "sinatra-assetpack", "~> 0.3.1", :require => "sinatra/assetpack"
  ```
 


### PR DESCRIPTION
`rubocop` now has a `require` so we need to change it to the old syntax for openshift.