### PR TITLE
Update Heroku.md (heroku addons:create)

### DIFF
--- a/docs/Heroku.md
+++ b/docs/Heroku.md
@@ -10,7 +10,7 @@ heroku config:set SECRET_TOKEN=`openssl rand -hex 20`
 heroku run rake db:migrate
 heroku restart
 
-heroku addons:add scheduler
+heroku addons:create scheduler
 heroku addons:open scheduler
 ```
 


### PR DESCRIPTION
> WARNING: `heroku addons:add` has been deprecated. Please use `heroku addons:create` instead.