### PR TITLE
Improving how data is passed to Delayed Job

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -46,7 +46,8 @@ desc "Work the delayed_job queue."
 task :work_jobs do
   Delayed::Job.delete_all
 
-  3.times do
+  worker_retry = Integer(ENV["WORKER_RETRY"] || 3)
+  worker_retry.times do
     Delayed::Worker.new(
       min_priority: ENV["MIN_PRIORITY"],
       max_priority: ENV["MAX_PRIORITY"]

--- a/app.json
+++ b/app.json
@@ -23,6 +23,14 @@
     "ENFORCE_SSL": {
       "description": "Force all clients to connect over SSL",
       "value": "true"
+    },
+    "WORKER_EMBEDDED": {
+      "description": "Force worker threads to be spawned by main process",
+      "value": "true"
+    },
+    "WORKER_RETRY": {
+      "description": "Number of times to respawn the worker thread if it fails",
+      "value": "3"
     }
   },
   "addons": [

--- a/app/tasks/fetch_feeds.rb
+++ b/app/tasks/fetch_feeds.rb
@@ -3,12 +3,17 @@ require "thread/pool"
 require_relative "fetch_feed"
 
 class FetchFeeds
-  def initialize(feeds, pool = Thread.pool(10))
+  def initialize(feeds, pool = nil)
+    @pool  = pool
     @feeds = feeds
-    @pool = pool
+    @feeds_ids = []
   end
 
   def fetch_all
+    @pool ||= Thread.pool(10)
+
+    @feeds = FeedRepository.fetch_by_ids(@feeds_ids) if @feeds.blank? && !@feeds_ids.blank?
+
     @feeds.each do |feed|
       @pool.process do
         FetchFeed.new(feed).fetch
@@ -20,7 +25,13 @@ class FetchFeeds
     @pool.shutdown
   end
 
+  def prepare_to_delay
+    @feeds_ids = @feeds.map(&:id)
+    @feeds = []
+    self
+  end
+
   def self.enqueue(feeds)
-    new(feeds).delay.fetch_all
+    new(feeds).prepare_to_delay.delay.fetch_all
   end
 end

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -9,7 +9,7 @@ before_fork do |_server, _worker|
   # as there's no need for the master process to hold a connection
   ActiveRecord::Base.connection.disconnect! if defined?(ActiveRecord::Base)
 
-  @delayed_job_pid ||= spawn("bundle exec rake work_jobs")
+  @delayed_job_pid ||= spawn("bundle exec rake work_jobs") unless ENV["WORKER_EMBEDDED"] == "false"
 
   sleep 1
 end


### PR DESCRIPTION
This PR intends to make the Delayed Job processing more robust.

In my tests, while running Stringer in a Docker container, there was an issue on passing the `Feed` data to the Delayed Job.

The whole object was serialized by the application (`FetchFeeds` class) and deserialized by the Delayed Job.
That's not a good practice and can cause several issues, as you can see in https://github.com/collectiveidea/delayed_job_active_record/issues/101

To solve this, instead of passing the whole `Feed` object to the Delayed Job, only its `id` attribute is sent. Then, the `Feed` is get from the database and its content is fetched normally.

Plus, the `@pool` object (a pool of threads) was also serialized and sent, causing issues.
If no `pool` is passed to the job, it should be instantiated from inside the job itself, avoiding the serialize/unserialize issues.
Keeping the `pool` argument in the `FetchFeeds#initialize` method ensures the tests can still mock it and run the defined `expect` clauses.

Finally, in order to make it easy to configure the worker component (set how many times it should be respawned; if it should be spawned by this process or it will be invoked elsewhere), couple optional env vars were added.