### PR TITLE
Adding clockwork to recurrently fetch feeds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ end
 gem "activerecord", "~> 4.1.11"
 gem "arel", "~> 5.0"
 gem "bcrypt-ruby", "~> 3.1.2"
+gem "clockwork", "~> 1.2"
 gem "delayed_job", "~> 4.1"
 gem "delayed_job_active_record", "~> 4.1"
 gem "feedbag", "~> 0.9.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    clockwork (1.2.0)
+      activesupport
+      tzinfo
     coderay (1.1.0)
     columnize (0.3.6)
     coveralls (0.7.0)
@@ -187,6 +190,7 @@ DEPENDENCIES
   arel (~> 5.0)
   bcrypt-ruby (~> 3.1.2)
   capybara (~> 2.4.1)
+  clockwork (~> 1.2.0)
   coveralls (~> 0.7)
   delayed_job (~> 4.1)
   delayed_job_active_record (~> 4.1)
@@ -217,3 +221,6 @@ DEPENDENCIES
   timecop (~> 0.7.1)
   unicorn (~> 4.7)
   will_paginate (~> 3.0, >= 3.0.5)
+
+BUNDLED WITH
+   1.11.2

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,4 @@
 web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb
+worker: bundle exec rake work_jobs
+clock: bundle exec clockwork lib/clock.rb
 console: bundle exec racksh

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -2,14 +2,17 @@ worker_processes 1
 timeout 30
 preload_app true
 
-@delayed_job_pid = nil
+work_pids = {}
 
 before_fork do |_server, _worker|
   # the following is highly recommended for Rails + "preload_app true"
   # as there's no need for the master process to hold a connection
   ActiveRecord::Base.connection.disconnect! if defined?(ActiveRecord::Base)
 
-  @delayed_job_pid ||= spawn("bundle exec rake work_jobs")
+  unless ENV["WORKER_EMBEDDED"] == "false"
+    work_pids[:delayed_job] ||= spawn("bundle exec rake work_jobs")
+    work_pids[:recurring_jobs] ||= spawn("bundle exec clockwork lib/clock.rb")
+  end
 
   sleep 1
 end

--- a/lib/clock.rb
+++ b/lib/clock.rb
@@ -1,0 +1,16 @@
+require "clockwork"
+require "delayed_job"
+require "delayed_job_active_record"
+
+require_relative "../app"
+require_relative "../app/jobs/fetch_feed_job"
+require_relative "../app/repositories/feed_repository"
+
+include Clockwork
+
+fetch_interval = (ENV["FETCH_INTERVAL"] || 10*60).to_i # Fetch every 10 minutes by default
+every(fetch_interval.seconds, "clockwork.frequent") do
+  FeedRepository.list.each do |feed|
+    Delayed::Job.enqueue FetchFeedJob.new(feed.id)
+  end
+end


### PR DESCRIPTION
This PR intends to add [`clockwork` gem](https://rubygems.org/gems/clockwork/versions/1.2.0) to recurrently fetch feeds.

It will replace [Scheduler](https://elements.heroku.com/addons/scheduler) (for deployment on Heroku), so that no extra step is needed due to another `spawn` command being called on `unicorn.rb` starting `clockwork`.

Still on Heroku, `Procfile` is updated, describing the `worker` and `clock` components (if the user wants a more robust architecture). This fixes #411 

Also, for development environments, it will allow fetching feeds without manually running `rake` commands.

The default interval for fetching feeds is 10 min and it can be customized by env var `FETCH_INTERVAL`.
