### PR TITLE
Fixing redirections between pages

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,6 +2,13 @@ require_relative "../commands/users/sign_in_user"
 
 class Stringer < Sinatra::Base
   get "/login" do
+    redirect to("/setup/password") unless UserRepository.created?
+
+    if authenticated?
+      redirect_uri = UserRepository.setup_complete? ? session.delete(:redirect_to) || "/news" : "/setup/tutorial"
+      redirect to(redirect_uri)
+    end
+
     erb :"sessions/new"
   end
 
@@ -10,7 +17,7 @@ class Stringer < Sinatra::Base
     if user
       session[:user_id] = user.id
 
-      redirect_uri = session.delete(:redirect_to) || "/"
+      redirect_uri = UserRepository.setup_complete? ? session.delete(:redirect_to) || "/news" : "/setup/tutorial"
       redirect to(redirect_uri)
     else
       flash.now[:error] = t("sessions.new.flash.wrong_password")

--- a/app/helpers/authentication_helpers.rb
+++ b/app/helpers/authentication_helpers.rb
@@ -17,7 +17,11 @@ module Sinatra
     end
 
     def current_user
-      UserRepository.fetch(session[:user_id])
+      begin
+        UserRepository.fetch(session[:user_id])
+      rescue
+        session[:user_id] = nil
+      end
     end
   end
 end

--- a/app/helpers/authentication_helpers.rb
+++ b/app/helpers/authentication_helpers.rb
@@ -5,23 +5,23 @@ require_relative "../repositories/user_repository"
 module Sinatra
   module AuthenticationHelpers
     def authenticated?
-      session[:user_id]
+      current_user.present?
     end
 
     def needs_authentication?(path)
-      return false if ENV["RACK_ENV"] == "test"
-      return false unless UserRepository.setup_complete?
-      return false if %w(/login /logout /heroku).include?(path)
+      return false if ENV["RACK_ENV"] == "test" && ENV["FORCE_TEST_AUTH"] != "true"
+      return false if %w(/login /logout /heroku /setup/password).include?(path)
       return false if path =~ /css|js|img/
       true
     end
 
+    def needs_setup_complete?(path)
+      return false if %w(/setup/tutorial /feeds/import).include?(path)
+      true
+    end
+
     def current_user
-      begin
-        UserRepository.fetch(session[:user_id])
-      rescue
-        session[:user_id] = nil
-      end
+      UserRepository.fetch(session[:user_id])
     end
   end
 end

--- a/app/repositories/user_repository.rb
+++ b/app/repositories/user_repository.rb
@@ -4,19 +4,19 @@ class UserRepository
   def self.fetch(id)
     return nil unless id
 
-    User.find(id)
+    User.find_by_id(id)
+  end
+
+  def self.created?
+    User.any?
   end
 
   def self.setup_complete?
-    User.any? && User.first.setup_complete?
+    self.created? && User.first.setup_complete?
   end
 
   def self.save(user)
     user.save
     user
-  end
-
-  def self.first
-    User.first
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,8 +25,8 @@ ActiveRecord::Schema.define(version: 20141102103617) do
     t.datetime "failed_at"
     t.string   "locked_by"
     t.string   "queue"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
@@ -35,8 +35,8 @@ ActiveRecord::Schema.define(version: 20141102103617) do
     t.string   "name"
     t.text     "url"
     t.datetime "last_fetched"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "status"
     t.integer  "group_id"
   end
@@ -54,8 +54,8 @@ ActiveRecord::Schema.define(version: 20141102103617) do
     t.text     "permalink"
     t.text     "body"
     t.integer  "feed_id"
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "published"
     t.boolean  "is_read"
     t.boolean  "keep_unread", default: false
@@ -67,8 +67,8 @@ ActiveRecord::Schema.define(version: 20141102103617) do
 
   create_table "users", force: true do |t|
     t.string   "password_digest"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.boolean  "setup_complete"
     t.string   "api_key"
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -3,6 +3,12 @@ require "spec_helper"
 app_require "controllers/sessions_controller"
 
 describe "SessionsController" do
+  before do
+    allow(UserRepository).to receive(:created?).and_return(true)
+    allow(UserRepository).to receive(:setup_complete?).and_return(true)
+    allow(UserRepository).to receive(:fetch).and_return(nil)
+  end
+
   describe "GET /login" do
     it "has a password input and login button" do
       get "/login"
@@ -31,7 +37,7 @@ describe "SessionsController" do
       expect(session[:user_id]).to eq 1
 
       expect(last_response.status).to be 302
-      expect(URI.parse(last_response.location).path).to eq "/"
+      expect(URI.parse(last_response.location).path).to eq "/news"
     end
 
     it "redirects to the previous path when present" do

--- a/spec/helpers/authentications_helper_spec.rb
+++ b/spec/helpers/authentications_helper_spec.rb
@@ -25,14 +25,6 @@ RSpec.describe Sinatra::AuthenticationHelpers do
       end
     end
 
-    context "when setup in not complete" do
-      it "returns false" do
-        allow(UserRepository).to receive(:setup_complete?).and_return(false)
-
-        expect(helper.needs_authentication?(authenticated_path)).to eq(false)
-      end
-    end
-
     %w(/login /logout /heroku).each do |path|
       context "when `path` is '#{path}'" do
         it "returns false" do


### PR DESCRIPTION
This PR intends to improve the redirections between Stringer pages. This should protect inner pages and expose only proper public pages.

If a user hasn't signed up yet, they shouldn't access inner pages (such as `/news`). In this case, those pages and the `/login` page should redirect to `/setup/password`.

If a user has signed up, but still hasn't completed the tutorial step (and they are logged in), inner pages, `/login`, `/setup/password` pages are all redirected to `/setup/tutorial`. The exception is `/feeds/import` page, which can be accessed even if the user hasn't complete the tutorial step.

In the same sense as above, if a user has signed up, but still hasn't completed the tutorial step (and they aren't logged in), the inner pages, `/setup/password` and `/feeds/import` pages are all redirected to `/login`.

If a user has signed up and has completed the tutorial step (and they are logged in), the `/setup/password` and `/login` page are redirected to `/news`.

In the same sense as above, if a user has signed up and has completed the tutorial step (and they aren't logged in), the internal pages and the `/setup/password` are all redirected to `/login`.
