### PR TITLE
Fixing SIL OFL links and typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ foreman start
 
 The application will be running on port `5000`.
 
-You can launch an interactive console (aka `rails c`) using `racksh`.
+You can launch an interactive console (a la `rails c`) using `racksh`.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ foreman start
 
 The application will be running on port `5000`.
 
-You can launch an interactive console (ala `rails c`) using `racksh`.
+You can launch an interactive console (aka `rails c`) using `racksh`.
 
 ## Acknowledgements
 
@@ -118,9 +118,9 @@ Most of the heavy-lifting is done by [`feedjira`](https://github.com/feedjira/fe
 
 General sexiness courtesy of [`Twitter Bootstrap`](http://twitter.github.io/bootstrap/) and [`Flat UI`](http://designmodo.github.io/Flat-UI/).
 
-ReenieBeanie Font Copyright &copy; 2010 Typeco (james@typeco.com). Licensed under [SIL Open Font License, 1.1](scripts.sil.org/OFL).
+ReenieBeanie Font Copyright &copy; 2010 Typeco (james@typeco.com). Licensed under [SIL Open Font License, 1.1](http://scripts.sil.org/OFL).
 
-Lato Font Copyright &copy; 2010-2011 by tyPoland Lukasz Dziedzic (team@latofonts.com). Licensed under [SIL Open Font License, 1.1](scripts.sil.org/OFL).
+Lato Font Copyright &copy; 2010-2011 by tyPoland Lukasz Dziedzic (team@latofonts.com). Licensed under [SIL Open Font License, 1.1](http://scripts.sil.org/OFL).
 
 ## Contact
 


### PR DESCRIPTION
This PR intends to fix the following items in README.md:
  - URLs for SIL OFL License;
  - a minor typo (`ala` instead of `a la`).