### PR TITLE
Explicitly set `db_dir` in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,7 @@ require "delayed_job"
 require "delayed_job_active_record"
 
 require "sinatra/activerecord/rake"
+ActiveRecord::Tasks::DatabaseTasks.db_dir = "db"
 
 require "./app"
 require_relative "./app/jobs/fetch_feed_job"


### PR DESCRIPTION
Fixes the following error introduced in 81a60ac44197a021aa8a7b9876acb3b6642436d8.

    rake aborted!
    NameError: uninitialized constant ActiveRecord::Tasks::DatabaseTasks::Rails
    /home/koronen/.gem/ruby/2.3.0/gems/activerecord-4.2.6/lib/active_record/tasks/database_tasks.rb:55:in `db_dir'
    /home/koronen/.gem/ruby/2.3.0/gems/sinatra-activerecord-1.7.0/lib/sinatra/activerecord/rake.rb:112:in `db_dir'

We set `db_dir` explicitly to prevent `ActiveRecord` from using a default value that references `Rails.application.config`.

Ref: <https://github.com/swanson/stringer/pull/428>

Fixes #436 and fixes #437.