### PR TITLE
Fix docs/VPS.md and add rel=noopener for privacy issue

### DIFF
--- a/app/public/js/app.js
+++ b/app/public/js/app.js
@@ -73,7 +73,9 @@ var Story = Backbone.Model.extend({
   },
 
   openInTab: function() {
-    window.open(this.get("permalink"), '_blank');
+    var otherWindow = window.open();
+    otherWindow.opener = null;
+    otherWindow.location = this.get("permalink");
   }
 });
 
@@ -144,8 +146,12 @@ var StoryView = Backbone.View.extend({
 
   storyClicked: function(e) {
     if (e.metaKey || e.ctrlKey || e.which == 2) {
-      var backgroundTab = window.open(this.model.get("permalink"));
-      if (backgroundTab) backgroundTab.blur();
+      var backgroundTab = window.open();
+      if (backgroundTab) {
+        backgroundTab.opener = null;
+        backgroundTab.location = this.model.get("permalink");
+        backgroundTab.blur();
+      }
       window.focus();
       if (!this.model.get("keep_unread")) this.model.set("is_read", true);
       if (this.model.shouldSave()) this.model.save();

--- a/app/views/js/templates/_story.js.erb
+++ b/app/views/js/templates/_story.js.erb
@@ -22,7 +22,7 @@
 
   <div class="story-body-container" class="row-fluid">
     <div class="story-body">
-      <h1><a href="{{= permalink }}">{{= title }}</a></h1>
+      <h1><a href="{{= permalink }}" rel="noopener noreferrer">{{= title }}</a></h1>
       {{= body }}
     </div>
     <div class="row-fluid story-actions-container">
@@ -38,7 +38,7 @@
         <div class="story-starred">
           <i class="icon-star{{ if(!is_starred) { }}-empty{{ } }}"></i>
         </div>
-        <a class="story-permalink" target="_blank" href="{{= permalink }}">
+        <a class="story-permalink" target="_blank" href="{{= permalink }}" rel="noopener noreferrer">
           <i class="icon-external-link"></i>
         </a>
       </div>

--- a/app/views/partials/_story.erb
+++ b/app/views/partials/_story.erb
@@ -24,7 +24,7 @@
 
     <div class="story-body-container" class="row-fluid" style="display: none;">
       <div class="story-body">
-        <h1><a href="<%=story.permalink %>"><%= story.title %></a></h1>
+        <h1><a href="<%=story.permalink %>" rel="noopener noreferrer"><%= story.title %></a></h1>
         <%= story.body %>
       </div>
       <div class="row-fluid story-actions-container">
@@ -37,7 +37,7 @@
           <a class="story-keep-unread" href="#">
             <i class="icon-check"></i> Keep unread
           </a>
-          <a class="story-permalink" href="<%= story.permalink %>">
+          <a class="story-permalink" href="<%= story.permalink %>" rel="noopener noreferrer">
             <i class="icon-external-link"></i>
           </a>
         </div>

--- a/docs/VPS.md
+++ b/docs/VPS.md
@@ -130,8 +130,10 @@ server {
     # https://mozilla.github.io/server-side-tls/ssl-config-generator/
     server_name example.com;
     location / {
-        proxy_pass http://127.0.0.1:1337/;
-        proxy_set_header Host $host;
+        proxy_pass http://127.0.0.1:1337/; # edit this
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
 ```


### PR DESCRIPTION
I got a redirect to login page while I'm trying to add new feed with nginx and SSL (in Chrome), these config can solve this issue.

```nginx
proxy_redirect off;
proxy_set_header X-Forwarded-Proto $scheme;
```

Also, I just added `rel=noopener` to all anchor tag for the privacy issue. (See: https://mathiasbynens.github.io/rel-noopener/)