### PR TITLE
Redirect to request.fullpath when request needs authentication

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -91,7 +91,7 @@ class Stringer < Sinatra::Base
     I18n.locale = ENV["LOCALE"].blank? ? :en : ENV["LOCALE"].to_sym
 
     if !authenticated? && needs_authentication?(request.path)
-      session[:redirect_to] = request.path
+      session[:redirect_to] = request.fullpath
       redirect "/login"
     end
   end


### PR DESCRIPTION
I often times add new feeds to Stringer via a Chrome extension that redirects to `<stringer>/feeds/new?feed_url=something`. I noticed that when I have to login I would always get redirected to `feeds/new` so Stringer was dropping the querystring.

This PR fixes that by settings `session[:redirect_to]` to `request.fullpath`, which does include the querystring.