### PR TITLE
Allow entries without an URL

### DIFF
--- a/app/repositories/story_repository.rb
+++ b/app/repositories/story_repository.rb
@@ -6,7 +6,7 @@ class StoryRepository
   extend UrlHelpers
 
   def self.add(entry, feed)
-    entry.url = normalize_url(entry.url, feed.url)
+    entry.url = normalize_url(entry.url, feed.url) unless entry.url.nil?
 
     Story.create(feed: feed,
                  title: sanitize(entry.title),


### PR DESCRIPTION
If you use a service that turns newsletters into RSS feeds, you will
receive entries without an URL. Saving those entries would fail when
normalizing the URL.