### PR TITLE
Update Docker docs to use image on Docker Hub

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,10 +1,21 @@
 #!/usr/bin/env sh
+if [ -z "$DATABASE_URL" ]; then
+  cat <<-EOF
+	$(tput setaf 1)Error: no DATABASE_URL was specified.
+
+	For a quick start use DATABASE_URL="sqlite3:':memory:'"
+	(not recommended for production).
+	EOF
+
+  exit 1
+fi
+
 : ${FETCH_FEEDS_CRON:='*/5 * * * *'}
 : ${CLEANUP_CRON:='0 0 * * *'}
 
-cat <<EOF > /app/crontab
-$FETCH_FEEDS_CRON cd /app && bundle exec rake fetch_feeds
-$CLEANUP_CRON cd /app && bundle exec rake cleanup_old_stories
+cat <<-EOF > /app/crontab
+	$FETCH_FEEDS_CRON cd /app && bundle exec rake fetch_feeds
+	$CLEANUP_CRON cd /app && bundle exec rake cleanup_old_stories
 EOF
 
 exec /usr/bin/supervisord -c /etc/supervisord.conf

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,5 +1,20 @@
 # Stringer on Docker
 
+## Quick test setup
+
+To quickly try out Stringer on your local machine run the following one liner:
+
+```sh
+docker run --rm -it -e DATABASE_URL="sqlite3:':memory:'" -p 8080:8080 mdswanson/stringer
+```
+
+Visit `http://localhost:8080` and enjoy Stringer!
+
+**One caveat**: Stringer was not designed to be used with sqlite so you might run into some issues if you
+have Stringer fetch many feeds. See [this issue](https://github.com/swanson/stringer/issues/164) for details.
+
+## Production ready setup
+
 The following steps can be used to setup Stringer on Docker, using a Postgres database also running on Docker.
 
 1. Setup a Docker network so the two containers we're going to create can communicate:
@@ -21,13 +36,7 @@ docker run --detach \
     postgres:9.5-alpine
 ```
 
-3. Build the Stringer Docker image:
-
-```sh
-docker build -t stringer .
-```
-
-4. And run it:
+3. Run the Stringer Docker image:
 
 ```sh
 docker run --detach \
@@ -40,7 +49,7 @@ docker run --detach \
     -e FETCH_FEEDS_CRON="*/5 * * * *" \ # optional
     -e CLEANUP_CRON="0 0 * * *" \ # optional
     -p 127.0.0.1:8080:8080 \
-    stringer
+    mdswanson/stringer
 ```
 
 That's it! You now have a fully working Stringer instance up and running!


### PR DESCRIPTION
This PR updates the Docker docs to use the prebuilt image from Docker hub that was setup in #458.

I've also added a check to the Docker start script that will warn and abort when the image is started without specifying a `DATABASE_URL`. This to prevent people trying to run the image without any env vars (`docker run -it mdswanson/stringer`) are greeted with a big stacktrace.