### PR TITLE
Add docker-compose example and update docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '2'
+services:
+  postgres:
+    image: postgres:9.5-alpine
+    restart: always
+    volumes:
+      - ~/stringer:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=super_secret_password
+      - POSTGRES_USER=db_user
+      - POSTGRES_DB=stringer
+
+  web:
+    image: mdswanson/stringer
+    depends_on:
+      - postgres
+    restart: always
+    ports:
+      - 80:8080
+    environment:
+      - SECRET_TOKEN=YOUR_SECRET_TOKEN
+      - PORT=8080
+      - DATABASE_URL=postgres://db_user:super_secret_password@postgres:5432/stringer

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -13,7 +13,11 @@ Visit `http://localhost:8080` and enjoy Stringer!
 **One caveat**: Stringer was not designed to be used with sqlite so you might run into some issues if you
 have Stringer fetch many feeds. See [this issue](https://github.com/swanson/stringer/issues/164) for details.
 
-## Production ready setup
+## Production ready setup using docker-compose
+
+Download [docker-compose.yml](../docker-compose.yml) and in the corresponding foler, run `docker-compose up -d`, give it a second and visit `localhost`
+
+## Production ready manual setup
 
 The following steps can be used to setup Stringer on Docker, using a Postgres database also running on Docker.
 
@@ -115,4 +119,3 @@ server {
         }
 }
 ```
-


### PR DESCRIPTION
If you're lazy like me, you try to automate your life. I've created this docker-compose example to quickly start up a Stringer instance and have all available options easily configured in one file, as opposed to running a containers manually using messy docker commands.