### PR TITLE
Use summary when there isn't a title

### DIFF
--- a/app/repositories/story_repository.rb
+++ b/app/repositories/story_repository.rb
@@ -9,7 +9,7 @@ class StoryRepository
     entry.url = normalize_url(entry.url, feed.url) unless entry.url.nil?
 
     Story.create(feed: feed,
-                 title: sanitize(entry.title),
+                 title: extract_title(entry),
                  permalink: entry.url,
                  body: extract_content(entry),
                  is_read: false,
@@ -93,6 +93,12 @@ class StoryRepository
     end
 
     expand_absolute_urls(sanitized_content, entry.url)
+  end
+
+  def self.extract_title(entry)
+    return sanitize(entry.title) if entry.title.present?
+    return sanitize(entry.summary) if entry.summary.present?
+    "There isn't a title for this story"
   end
 
   def self.sanitize(content)


### PR DESCRIPTION
Follwing the [spec](https://validator.w3.org/feed/docs/rss2.html#hrelementsOfLtitemgt) for RSS, if the title property isn't present for a story, we should display the description, which is the [summary in feedjira](https://github.com/feedjira/feedjira/blob/d0a28c3ba6437d70e4ca886ae5c05287bf1b6821/lib/feedjira/parser/itunes_rss_item.rb#L13).