### PR TITLE
Strip url before parse it

### DIFF
--- a/app/helpers/url_helpers.rb
+++ b/app/helpers/url_helpers.rb
@@ -25,11 +25,11 @@ module UrlHelpers
   end
 
   def normalize_url(url, base_url)
-    uri = URI.parse(url)
+    uri = URI.parse(url.strip)
 
     # resolve (protocol) relative URIs
     if uri.relative?
-      base_uri = URI.parse(base_url)
+      base_uri = URI.parse(base_url.strip)
       scheme = base_uri.scheme || "http"
       uri = URI.join("#{scheme}://#{base_uri.host}", uri)
     end


### PR DESCRIPTION
The link field of this [feed](https://www.qdaily.com/feed.xml) contains whitespace, got this error:
`bad URI(is not URI?):   (URI::InvalidURIError)`

Strip the url before parsing it solve the problem.