### PR TITLE
Upgrade Unicorn

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -21,3 +21,7 @@ after_fork do |_server, _worker|
     ActiveRecord::Base.establish_connection(config)
   end
 end
+
+after_worker_exit do |_server, _worker, _status|
+  Process.kill("QUIT", @delayed_job_pid) if !ENV["RACK_ENV"] || ENV["RACK_ENV"] == "development"
+end


### PR DESCRIPTION
In this change I'm upgrading unicorn in order to get the call back
`after_worker_exit`. I need this in development to kill ghost workers
that are pilling up on my computer every time I restart the app.