### PR TITLE
Bump nokogiri to address CVE-2017-15412

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     minitest (5.8.4)
     multi_json (1.12.1)
     multipart-post (2.0.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     parser (2.3.0.6)
       ast (~> 2.2)


### PR DESCRIPTION
As reported by `bundler-audit`:

> Name: nokogiri
> Version: 1.8.1
> Advisory: CVE-2017-15412
> Criticality: Unknown
> URL: https://github.com/sparklemotion/nokogiri/issues/1714
> Title: Nokogiri gem, via libxml, is affected by DoS vulnerabilities
> Solution: upgrade to >= 1.8.2