### PR TITLE
Bump loofah to address CVE-2018-8048

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
     i18n (0.7.0)
     json (1.8.3)
     kgio (2.10.0)
-    loofah (2.1.1)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (0.8.2)


### PR DESCRIPTION
As reported by `bundler-audit`:

> Name: loofah
> Version: 2.1.1
> Advisory: CVE-2018-8048
> Criticality: Unknown
> URL: https://github.com/flavorjones/loofah/issues/144
> Title: Loofah XSS Vulnerability
> Solution: upgrade to >= 2.2.1

Ref: <https://github.com/flavorjones/loofah/blob/v2.2.1/CHANGELOG.md#221--2018-03-19>