### PR TITLE
Prevents crash when both url and enclosure_url dont exist

### DIFF
--- a/app/repositories/story_repository.rb
+++ b/app/repositories/story_repository.rb
@@ -82,7 +82,7 @@ class StoryRepository
   end
 
   def self.extract_url(entry, feed)
-    return entry.enclosure_url if entry.url.nil? && entry.enclosure_url.present?
+    return entry.enclosure_url if entry.url.nil? && entry.respond_to?(:enclosure_url)
 
     normalize_url(entry.url, feed.url) unless entry.url.nil?
   end

--- a/spec/repositories/story_repository_spec.rb
+++ b/spec/repositories/story_repository_spec.rb
@@ -40,6 +40,13 @@ describe StoryRepository do
 
       expect(StoryRepository.extract_url(entry, feed)).to eq "https://github.com/swanson/stringer"
     end
+
+    it "does not crash if url is nil but enclosure_url does not exist" do
+      feed = double(url: "http://github.com")
+      entry = double(url: nil)
+
+      expect(StoryRepository.extract_url(entry, feed)).to eq nil
+    end
   end
 
   describe ".extract_title" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,9 +8,6 @@ require "faker"
 require "ostruct"
 require "date"
 
-require "coveralls"
-Coveralls.wear!
-
 require "factories/feed_factory"
 require "factories/story_factory"
 require "factories/user_factory"


### PR DESCRIPTION
[this commit](https://github.com/swanson/stringer/commit/b4ae4c1d43c9f0bd597e76dcb3324ac6f89e8359) made the whole process fail when both url and enclosure_url do not exist. The reason is that `entry.enclosure_url.present?` throws an error, since the method doesn't exist at all

There's actually a much larger issue here, which is the error being silently hidden in `FetchFeed`, which just rescues every exception and flags the feed as red. This makes it very hard to debug errors

However I just fixed this one issue. I hope after re-deploying, my feeds will start working again, otherwise I'll have to get back at it