### PR TITLE
Fixes entry parse if there is no URL

### DIFF
--- a/app/repositories/story_repository.rb
+++ b/app/repositories/story_repository.rb
@@ -96,7 +96,11 @@ class StoryRepository
       sanitized_content = sanitize(entry.summary)
     end
 
-    expand_absolute_urls(sanitized_content, entry.url)
+    if entry.url.present?
+      expand_absolute_urls(sanitized_content, entry.url)
+    else
+      sanitized_content
+    end
   end
 
   def self.extract_title(entry)

--- a/spec/repositories/story_repository_spec.rb
+++ b/spec/repositories/story_repository_spec.rb
@@ -85,6 +85,22 @@ describe StoryRepository do
     it "falls back to summary if there is no content" do
       expect(StoryRepository.extract_content(summary_only)).to eq "Dumb publisher"
     end
+
+    it "expands urls" do
+      entry = double(url: "http://mdswanson.com",
+                     content: nil,
+                     summary: "<a href=\"page\">Page</a>")
+
+      expect(StoryRepository.extract_content(entry)).to eq "<a href=\"http://mdswanson.com/page\">Page</a>"
+    end
+
+    it "ignores URL expansion if entry url is nil" do
+      entry = double(url: nil,
+                     content: nil,
+                     summary: "<a href=\"page\">Page</a>")
+
+      expect(StoryRepository.extract_content(entry)).to eq "<a href=\"page\">Page</a>"
+    end
   end
 
   describe ".sanitize" do


### PR DESCRIPTION
Parsing was failing if an entry had no defined URL. The parser was assuming it existed, and using it to expand all relative URLs

While it probably always exists for any well-made RSS feed, it won't be true if we're using something like [Kill The Newsletter](https://www.kill-the-newsletter.com/) to convert emails to RSS