### PR TITLE
Bugfix: bump unicorn for after_worker_exit feature

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 group :production do
   gem "pg", "~> 0.18.4"
-  gem "unicorn", "~> 4.7"
+  gem "unicorn", "~> 5.3"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     json (1.8.6)
-    kgio (2.10.0)
+    kgio (2.11.2)
     loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -89,7 +89,7 @@ GEM
     pry-byebug (1.3.3)
       byebug (~> 2.7)
       pry (~> 0.10)
-    rack (1.6.5)
+    rack (1.6.10)
     rack-protection (1.5.3)
       rack
     rack-ssl (1.4.1)
@@ -100,7 +100,7 @@ GEM
       rack (>= 1.0)
       rack-test (>= 0.5)
     rainbow (2.1.0)
-    raindrops (0.16.0)
+    raindrops (0.19.0)
     rake (10.5.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
@@ -170,9 +170,8 @@ GEM
     uglifier (3.0.2)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.0.2)
-    unicorn (4.9.0)
+    unicorn (5.4.0)
       kgio (~> 2.6)
-      rack
       raindrops (~> 0.7)
     will_paginate (3.1.0)
     xpath (2.0.0)
@@ -216,7 +215,7 @@ DEPENDENCIES
   thread (~> 0.2)
   timecop (~> 0.8)
   uglifier
-  unicorn (~> 4.7)
+  unicorn (~> 5.3)
   will_paginate (~> 3.1)
 
 RUBY VERSION


### PR DESCRIPTION
    NoMethodError: undefined method `after_worker_exit' for
      #<Unicorn::Configurator:0x005580f92c7480>
    Did you mean?  after_fork
      ./config/unicorn.rb:25:in `reload'

This was probably meant to be a part of d73a7d7381f5bb1ece51819db41caa05a0831cbf (#475).

Fixes #483.

Ref: <https://bogomips.org/unicorn/NEWS.html#label-unicorn+5.3.0+-2F+2017-04-01+08-3A03+UTC>