### PR TITLE
Gemnasium is migratet to Gitlab and closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](https://api.travis-ci.org/swanson/stringer.svg?style=flat)](https://travis-ci.org/swanson/stringer)
 [![Code Climate](https://codeclimate.com/github/swanson/stringer.svg?style=flat)](https://codeclimate.com/github/swanson/stringer)
 [![Coverage Status](https://coveralls.io/repos/swanson/stringer/badge.svg?style=flat)](https://coveralls.io/r/swanson/stringer)
-[![Dependency Status](https://gemnasium.com/swanson/stringer.svg)](https://gemnasium.com/swanson/stringer)
 
 ### A self-hosted, anti-social RSS reader.
 


### PR DESCRIPTION
What happened to my badge? 
To avoid broken 404 images, all badges pointing to Gemnasium.com will be a placeholder, inviting you to migrate to GitLab (and pointing to this page).

https://docs.gitlab.com/ee/user/project/import/gemnasium.html