### PR TITLE
Bump nokogiri to address CVE-2018-8048 and CVE-2018-14404

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     minitest (5.11.3)
     multi_json (1.12.1)
     multipart-post (2.0.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     parser (2.3.0.6)
       ast (~> 2.2)
@@ -222,4 +222,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.16.1
+   1.17.1


### PR DESCRIPTION
As reported by `bundler-audit`:

    Name: nokogiri
    Version: 1.8.2
    Advisory: CVE-2018-8048
    Criticality: Unknown
    URL: https://github.com/sparklemotion/nokogiri/pull/1746
    Title: Revert libxml2 behavior in Nokogiri gem that could cause XSS
    Solution: upgrade to >= 1.8.3

    Name: nokogiri
    Version: 1.8.2
    Advisory: CVE-2018-14404
    Criticality: Unknown
    URL: https://github.com/sparklemotion/nokogiri/issues/1785
    Title: Nokogiri gem, via libxml2, is affected by multiple vulnerabilities
    Solution: upgrade to >= 1.8.5