### PR TITLE
Bump loofah to address CVE-2018-16468

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (1.8.6)
     kgio (2.11.2)
-    loofah (2.2.1)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (0.8.2)


### PR DESCRIPTION
As reported by `bundler-audit`:

    Name: loofah
    Version: 2.2.1
    Advisory: CVE-2018-16468
    Criticality: Unknown
    URL: https://github.com/flavorjones/loofah/issues/154
    Title: Loofah XSS Vulnerability
    Solution: upgrade to >= 2.2.3