### PR TITLE
Update command for setting APP_URL on Heroku

### DIFF
--- a/docs/Heroku.md
+++ b/docs/Heroku.md
@@ -4,7 +4,7 @@ cd stringer
 heroku create
 git push heroku master
 
-heroku config:set APP_URL=`heroku apps:info --shell | grep web-url | cut -d= -f2`
+heroku config:set APP_URL=`heroku apps:info --shell | grep web_url | cut -d= -f2`
 heroku config:set SECRET_TOKEN=`openssl rand -hex 20`
 
 heroku run rake db:migrate


### PR DESCRIPTION
* `web-url` in the `heroku apps:info` output is now `web_url`
* Command was returning an empty string and setting that as the value of `APP_URL`