### PR TITLE
Updated bcrypt from v3.1 to v3.1.12

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :development, :test do
 end
 
 gem "activerecord", "~> 4.2.6"
-gem "bcrypt", "~> 3.1"
+gem "bcrypt", "~> 3.1.12"
 gem "delayed_job", "~> 4.1"
 gem "delayed_job_active_record", "~> 4.1"
 gem "feedbag", "~> 0.9.5"


### PR DESCRIPTION
Personally I was getting 500 erorrs when trying to set up the password, and was getting the following InvalidHash errors. This resolution in an unrelated project that also uses bcrypted resolved this issue for me: https://github.com/heartcombo/devise/issues/4861


```
D, [2020-09-03T10:16:28.318049 #2019485] DEBUG -- :   SQL (0.4ms)  DELETE FROM "users"
2020-09-03 10:16:28 - BCrypt::Errors::InvalidHash - invalid hash:
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bcrypt-3.1.11/lib/bcrypt/password.rb:60:in `initialize'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bcrypt-3.1.11/lib/bcrypt/password.rb:46:in `new'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bcrypt-3.1.11/lib/bcrypt/password.rb:46:in `create'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activemodel-4.2.10/lib/active_model/secure_password.rb:125:in `password='
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-4.2.10/lib/active_record/attribute_assignment.rb:54:in `public_send'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-4.2.10/lib/active_record/attribute_assignment.rb:54:in `_assign_attribute'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-4.2.10/lib/active_record/attribute_assignment.rb:41:in `block in assign_attributes'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-4.2.10/lib/active_record/attribute_assignment.rb:35:in `each'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-4.2.10/lib/active_record/attribute_assignment.rb:35:in `assign_attributes'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-4.2.10/lib/active_record/core.rb:566:in `init_attributes'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-4.2.10/lib/active_record/core.rb:281:in `initialize'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-4.2.10/lib/active_record/inheritance.rb:61:in `new'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-4.2.10/lib/active_record/inheritance.rb:61:in `new'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activerecord-4.2.10/lib/active_record/persistence.rb:33:in `create'
        /home/stringer/stringer/app/commands/users/create_user.rb:10:in `create'
        /home/stringer/stringer/app/controllers/first_run_controller.rb:23:in `block (2 levels) in <class:Stringer>'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1611:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1611:in `block in compile!'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:975:in `block (3 levels) in route!'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:994:in `route_eval'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:975:in `block (2 levels) in route!'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1015:in `block in process_route'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1013:in `catch'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1013:in `process_route'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:973:in `block in route!'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:972:in `each'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:972:in `route!'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1085:in `block in dispatch!'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `block in invoke'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `catch'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `invoke'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1082:in `dispatch!'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:907:in `block in call!'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `block in invoke'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `catch'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `invoke'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:907:in `call!'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:895:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-protection-1.5.5/lib/rack/protection/xss_header.rb:18:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-protection-1.5.5/lib/rack/protection/base.rb:49:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-protection-1.5.5/lib/rack/protection/base.rb:49:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-protection-1.5.5/lib/rack/protection/path_traversal.rb:16:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-protection-1.5.5/lib/rack/protection/json_csrf.rb:18:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-protection-1.5.5/lib/rack/protection/base.rb:49:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-protection-1.5.5/lib/rack/protection/base.rb:49:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-protection-1.5.5/lib/rack/protection/frame_options.rb:31:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-1.6.12/lib/rack/session/abstract/id.rb:252:in `context'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-1.6.12/lib/rack/session/abstract/id.rb:247:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-1.6.12/lib/rack/logger.rb:15:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-1.6.12/lib/rack/commonlogger.rb:33:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:219:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:212:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-1.6.12/lib/rack/head.rb:13:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-1.6.12/lib/rack/methodoverride.rb:22:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:182:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:2013:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1487:in `block in call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1787:in `synchronize'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1487:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-1.6.12/lib/rack/urlmap.rb:66:in `block in call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-1.6.12/lib/rack/urlmap.rb:50:in `each'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/rack-1.6.12/lib/rack/urlmap.rb:50:in `call'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/unicorn-5.4.0/lib/unicorn/http_server.rb:606:in `process_client'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/unicorn-5.4.0/lib/unicorn/http_server.rb:701:in `worker_loop'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/unicorn-5.4.0/lib/unicorn/http_server.rb:549:in `spawn_missing_workers'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/unicorn-5.4.0/lib/unicorn/http_server.rb:142:in `start'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/unicorn-5.4.0/bin/unicorn:126:in `<top (required)>'
        /home/stringer/.rbenv/versions/2.6.5/bin/unicorn:23:in `load'
        /home/stringer/.rbenv/versions/2.6.5/bin/unicorn:23:in `<top (required)>'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/cli/exec.rb:74:in `load'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/cli/exec.rb:74:in `kernel_load'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/cli/exec.rb:28:in `run'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/cli.rb:463:in `exec'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/cli.rb:27:in `dispatch'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/cli.rb:18:in `start'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-1.17.2/exe/bundle:30:in `block in <top (required)>'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/2.6.0/bundler/friendly_errors.rb:124:in `with_friendly_errors'
        /home/stringer/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-1.17.2/exe/bundle:22:in `<top (required)>'
        /home/stringer/.rbenv/versions/2.6.5/bin/bundle:23:in `load'
        /home/stringer/.rbenv/versions/2.6.5/bin/bundle:23:in `<main>'
127.0.0.1 - - [03/Sep/2020:10:16:28 +0000] "POST /setup/password HTTP/1.0" 500 30 0.0864
```