### PR TITLE
Add web manifest to enable native app feel on mobile

### DIFF
--- a/app/public/manifest.json
+++ b/app/public/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "Stringer",
+  "theme_color": "#F67100",
+  "background_color": "#FAF2E5",
+  "display": "standalone",
+  "start_url": "/"
+}

--- a/app/views/layout.erb
+++ b/app/views/layout.erb
@@ -10,6 +10,11 @@
     <link rel="shortcut icon" href="/img/favicon.png">
     <link rel="apple-touch-icon-precomposed" href="/img/apple-touch-icon-precomposed.png">
 
+    <link rel="manifest" href="/manifest.json">
+
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+
     <%= yield_content :head %>
 
     <link href="<%= stylesheet_path 'application' %>" rel="stylesheet" />


### PR DESCRIPTION
- by adding the meta headers and manifest, if you add the website on mobile to you home screen, the browser chrome will dissappear and more screen space will be available for the reader