### PR TITLE
Specs: restore coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :development, :test do
   gem "rspec", "~> 3.4"
   gem "rspec-html-matchers", "~> 0.7"
   gem "shotgun", "~> 0.9"
+  gem "simplecov"
   gem "timecop", "~> 0.8"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,7 @@ DEPENDENCIES
   rubocop (>= 0.61.1)
   sass
   shotgun (~> 0.9)
+  simplecov
   sinatra (~> 1.4.8, >= 1.4.8)
   sinatra-activerecord (~> 1.2, >= 1.2.3)
   sinatra-contrib (~> 1.4.7)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require "faker"
 require "ostruct"
 require "date"
 
+require_relative "support/coverage"
 require "factories/feed_factory"
 require "factories/story_factory"
 require "factories/user_factory"

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -1,0 +1,17 @@
+require "simplecov"
+
+if ENV["CI"]
+  require "coveralls"
+  SimpleCov.formatter = Coveralls::SimpleCov::Formatter
+end
+
+SimpleCov.start("test_frameworks") do
+  add_group("Commands", "app/commands")
+  add_group("Controllers", "app/controllers")
+  add_group("Fever API", "app/fever_api")
+  add_group("Helpers", "app/helpers")
+  add_group("Models", "app/models")
+  add_group("Repositories", "app/repositories")
+  add_group("Tasks", "app/tasks")
+  add_group("Utils", "app/utils")
+end


### PR DESCRIPTION
It looks like Coveralls was disabled back in c84d7b8, but it seems to
have been unrelated to the code changes. This reenables it on CI, and
uses just `SimpleCov` in local development.
