### PR TITLE
Update to activerecord 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :development, :test do
   gem "timecop", "~> 0.8"
 end
 
-gem "activerecord", "~> 4.2.6"
+gem "activerecord", "~> 5.0"
 gem "bcrypt", "~> 3.1"
 gem "delayed_job", "~> 4.1"
 gem "delayed_job_active_record", "~> 4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.10)
-      activesupport (= 4.2.10)
-      builder (~> 3.1)
-    activerecord (4.2.10)
-      activemodel (= 4.2.10)
-      activesupport (= 4.2.10)
-      arel (~> 6.0)
-    activesupport (4.2.10)
-      i18n (~> 0.7)
+    activemodel (5.2.4.5)
+      activesupport (= 5.2.4.5)
+    activerecord (5.2.4.5)
+      activemodel (= 5.2.4.5)
+      activesupport (= 5.2.4.5)
+      arel (>= 9.0)
+    activesupport (5.2.4.5)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
-    arel (6.0.4)
+    arel (9.0.0)
     ast (2.4.0)
     backports (3.6.8)
     bcrypt (3.1.11)
@@ -187,7 +186,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (~> 4.2.6)
+  activerecord (~> 5.0)
   bcrypt (~> 3.1)
   capybara (~> 2.6)
   coveralls (~> 0.7)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -1,4 +1,6 @@
-class Feed < ActiveRecord::Base
+require_relative "./application_record"
+
+class Feed < ApplicationRecord
   has_many :stories, -> { order "published desc" }, dependent: :delete_all
   belongs_to :group
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,6 @@
-class Group < ActiveRecord::Base
+require_relative "./application_record"
+
+class Group < ApplicationRecord
   has_many :feeds
 
   def as_fever_json

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,6 +1,7 @@
+require_relative "./application_record"
 require_relative "./feed"
 
-class Story < ActiveRecord::Base
+class Story < ApplicationRecord
   belongs_to :feed
 
   validates_uniqueness_of :entry_id, scope: :feed_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
-class User < ActiveRecord::Base
+require_relative "./application_record"
+
+class User < ApplicationRecord
   has_secure_password
 end

--- a/db/migrate/20130409010818_create_feeds.rb
+++ b/db/migrate/20130409010818_create_feeds.rb
@@ -1,4 +1,4 @@
-class CreateFeeds < ActiveRecord::Migration
+class CreateFeeds < ActiveRecord::Migration[4.2]
   def change
     create_table :feeds do |t|
       t.string :name

--- a/db/migrate/20130409010826_create_stories.rb
+++ b/db/migrate/20130409010826_create_stories.rb
@@ -1,4 +1,4 @@
-class CreateStories < ActiveRecord::Migration
+class CreateStories < ActiveRecord::Migration[4.2]
   def change
     create_table :stories do |t|
       t.string :title

--- a/db/migrate/20130412185253_add_new_fields_to_stories.rb
+++ b/db/migrate/20130412185253_add_new_fields_to_stories.rb
@@ -1,4 +1,4 @@
-class AddNewFieldsToStories < ActiveRecord::Migration
+class AddNewFieldsToStories < ActiveRecord::Migration[4.2]
   def change
     add_column :stories, :published, :timestamp
     add_column :stories, :is_read, :boolean

--- a/db/migrate/20130418221144_add_user_model.rb
+++ b/db/migrate/20130418221144_add_user_model.rb
@@ -1,4 +1,4 @@
-class AddUserModel < ActiveRecord::Migration
+class AddUserModel < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
       t.string :email

--- a/db/migrate/20130423001740_drop_email_from_user.rb
+++ b/db/migrate/20130423001740_drop_email_from_user.rb
@@ -1,4 +1,4 @@
-class DropEmailFromUser < ActiveRecord::Migration
+class DropEmailFromUser < ActiveRecord::Migration[4.2]
   def up
     remove_column :users, :email
   end

--- a/db/migrate/20130423180446_remove_author_from_stories.rb
+++ b/db/migrate/20130423180446_remove_author_from_stories.rb
@@ -1,4 +1,4 @@
-class RemoveAuthorFromStories < ActiveRecord::Migration
+class RemoveAuthorFromStories < ActiveRecord::Migration[4.2]
   def up
     remove_column :stories, :author
   end

--- a/db/migrate/20130425211008_add_setup_complete_to_user.rb
+++ b/db/migrate/20130425211008_add_setup_complete_to_user.rb
@@ -1,4 +1,4 @@
-class AddSetupCompleteToUser < ActiveRecord::Migration
+class AddSetupCompleteToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :setup_complete, :boolean
   end

--- a/db/migrate/20130425222157_add_delayed_job.rb
+++ b/db/migrate/20130425222157_add_delayed_job.rb
@@ -1,4 +1,4 @@
-class AddDelayedJob < ActiveRecord::Migration
+class AddDelayedJob < ActiveRecord::Migration[4.2]
   def self.up
     create_table :delayed_jobs, force: true do |table|
       # Allows some jobs to jump to the front of the queue

--- a/db/migrate/20130429232127_add_status_to_feeds.rb
+++ b/db/migrate/20130429232127_add_status_to_feeds.rb
@@ -1,4 +1,4 @@
-class AddStatusToFeeds < ActiveRecord::Migration
+class AddStatusToFeeds < ActiveRecord::Migration[4.2]
   def change
     add_column :feeds, :status, :int
   end

--- a/db/migrate/20130504005816_text_url.rb
+++ b/db/migrate/20130504005816_text_url.rb
@@ -1,4 +1,4 @@
-class TextUrl < ActiveRecord::Migration
+class TextUrl < ActiveRecord::Migration[4.2]
   def up
     change_column :feeds, :url, :text
   end

--- a/db/migrate/20130504022615_change_story_permalink_column.rb
+++ b/db/migrate/20130504022615_change_story_permalink_column.rb
@@ -1,4 +1,4 @@
-class ChangeStoryPermalinkColumn < ActiveRecord::Migration
+class ChangeStoryPermalinkColumn < ActiveRecord::Migration[4.2]
   def up
     change_column :stories, :permalink, :text
   end

--- a/db/migrate/20130509131045_add_unique_constraints.rb
+++ b/db/migrate/20130509131045_add_unique_constraints.rb
@@ -1,4 +1,4 @@
-class AddUniqueConstraints < ActiveRecord::Migration
+class AddUniqueConstraints < ActiveRecord::Migration[4.2]
   def change
     add_index :stories, [:permalink, :feed_id], unique: true
     add_index :feeds, :url, unique: true

--- a/db/migrate/20130513025939_add_keep_unread_to_stories.rb
+++ b/db/migrate/20130513025939_add_keep_unread_to_stories.rb
@@ -1,4 +1,4 @@
-class AddKeepUnreadToStories < ActiveRecord::Migration
+class AddKeepUnreadToStories < ActiveRecord::Migration[4.2]
   def change
     add_column :stories, :keep_unread, :boolean, default: false
   end

--- a/db/migrate/20130513044029_add_is_starred_status_for_stories.rb
+++ b/db/migrate/20130513044029_add_is_starred_status_for_stories.rb
@@ -1,4 +1,4 @@
-class AddIsStarredStatusForStories < ActiveRecord::Migration
+class AddIsStarredStatusForStories < ActiveRecord::Migration[4.2]
   def change
     add_column :stories, :is_starred, :boolean, default: false
   end

--- a/db/migrate/20130522014405_add_api_key_to_user.rb
+++ b/db/migrate/20130522014405_add_api_key_to_user.rb
@@ -1,4 +1,4 @@
-class AddApiKeyToUser < ActiveRecord::Migration
+class AddApiKeyToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :api_key, :string
   end

--- a/db/migrate/20130730120312_add_entry_id_to_stories.rb
+++ b/db/migrate/20130730120312_add_entry_id_to_stories.rb
@@ -1,4 +1,4 @@
-class AddEntryIdToStories < ActiveRecord::Migration
+class AddEntryIdToStories < ActiveRecord::Migration[4.2]
   def change
     add_column :stories, :entry_id, :string
   end

--- a/db/migrate/20130805113712_update_stories_unique_constraints.rb
+++ b/db/migrate/20130805113712_update_stories_unique_constraints.rb
@@ -1,4 +1,4 @@
-class UpdateStoriesUniqueConstraints < ActiveRecord::Migration
+class UpdateStoriesUniqueConstraints < ActiveRecord::Migration[4.2]
   def up
     remove_index :stories, [:permalink, :feed_id]
     add_index :stories, [:entry_id, :feed_id], unique: true, length: { permalink: 767 }

--- a/db/migrate/20130821020313_update_nil_entry_ids.rb
+++ b/db/migrate/20130821020313_update_nil_entry_ids.rb
@@ -1,4 +1,4 @@
-class UpdateNilEntryIds < ActiveRecord::Migration
+class UpdateNilEntryIds < ActiveRecord::Migration[4.2]
   def up
     Story.where(entry_id: nil).each do |story|
       story.entry_id = story.permalink || story.id

--- a/db/migrate/20130905204142_use_text_datatype_for_title_and_entry_id.rb
+++ b/db/migrate/20130905204142_use_text_datatype_for_title_and_entry_id.rb
@@ -1,4 +1,4 @@
-class UseTextDatatypeForTitleAndEntryId < ActiveRecord::Migration
+class UseTextDatatypeForTitleAndEntryId < ActiveRecord::Migration[4.2]
   def up
     change_column :stories, :title, :text
     change_column :stories, :entry_id, :text

--- a/db/migrate/20140413100725_add_groups_table_and_foreign_keys_to_feeds.rb
+++ b/db/migrate/20140413100725_add_groups_table_and_foreign_keys_to_feeds.rb
@@ -1,4 +1,4 @@
-class AddGroupsTableAndForeignKeysToFeeds < ActiveRecord::Migration
+class AddGroupsTableAndForeignKeysToFeeds < ActiveRecord::Migration[4.2]
   def up
     create_table :groups do |t|
       t.string :name, null: false

--- a/db/migrate/20140421224454_fix_invalid_unicode.rb
+++ b/db/migrate/20140421224454_fix_invalid_unicode.rb
@@ -1,4 +1,4 @@
-class FixInvalidUnicode < ActiveRecord::Migration
+class FixInvalidUnicode < ActiveRecord::Migration[4.2]
   def up
     Story.find_each do |story|
       valid_body = story.body.delete("\u2028").delete("\u2029")

--- a/db/migrate/20141102103617_fix_invalid_titles_with_unicode_line_endings.rb
+++ b/db/migrate/20141102103617_fix_invalid_titles_with_unicode_line_endings.rb
@@ -1,4 +1,4 @@
-class FixInvalidTitlesWithUnicodeLineEndings < ActiveRecord::Migration
+class FixInvalidTitlesWithUnicodeLineEndings < ActiveRecord::Migration[4.2]
   def up
     Story.find_each do |story|
       unless story.title.nil?

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -5,10 +5,10 @@ ActiveRecord::Base.establish_connection(db_config["test"])
 ActiveRecord::Base.logger = Logger.new("log/test.log")
 
 def need_to_migrate?
-  ActiveRecord::Migrator.new(:up, ActiveRecord::Migrator.migrations("db/migrate")).pending_migrations.any?
+  ActiveRecord::Base.connection.migration_context.needs_migration?
 end
 
-ActiveRecord::Migrator.up "db/migrate" if need_to_migrate?
+ActiveRecord::MigrationContext.new("db/migrate").migrate if need_to_migrate?
 
 RSpec.configure do |config|
   config.around do |example|


### PR DESCRIPTION
Followed the instructions at https://www.fastruby.io/blog/rails/upgrades/upgrade-rails-from-4-2-to-5-0.html to migrate to the newer version. Then fixed the `pec/support/active_record.rb` calls to work with the new API.