### PR TITLE
Specs: add specs for StoryRepository

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,15 @@
+require_relative "factories/feed_factory"
+require_relative "factories/story_factory"
+require_relative "factories/user_factory"
+require_relative "factories/group_factory"
+require_relative "factories/feeds"
+require_relative "factories/groups"
+require_relative "factories/stories"
+require_relative "factories/users"
+
+module Factories
+  def next_id
+    @next_id ||= 0
+    @next_id += 1
+  end
+end

--- a/spec/factories/stories.rb
+++ b/spec/factories/stories.rb
@@ -4,6 +4,6 @@ module Factories
   end
 
   def build_story(params = {})
-    Story.new(feed: build_feed, **params)
+    Story.new(entry_id: next_id, feed: build_feed, **params)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,14 +9,7 @@ require "ostruct"
 require "date"
 
 require_relative "support/coverage"
-require "factories/feed_factory"
-require "factories/story_factory"
-require "factories/user_factory"
-require "factories/group_factory"
-require "factories/feeds"
-require "factories/groups"
-require "factories/stories"
-require "factories/users"
+require_relative "factories"
 
 require "./app"
 


### PR DESCRIPTION
Also adjust the way that factories are required and introduce a
`next_id` helper. There are still some untested methods in
StoryRepository which I will continue to work on in followups.
