### PR TITLE
refactor specs for ChangePassword

### DIFF
--- a/app/tasks/change_password.rb
+++ b/app/tasks/change_password.rb
@@ -3,13 +3,15 @@ require "io/console"
 require_relative "../commands/users/change_user_password"
 
 class ChangePassword
-  def initialize(command = ChangeUserPassword.new)
+  def initialize(command = ChangeUserPassword.new, output: $stdout, input: $stdin)
     @command = command
+    @output = output
+    @input = input
   end
 
   def change_password
     while (password = ask_password) != ask_confirmation
-      puts "The confirmation doesn't match the password. Please try again."
+      @output.puts "The confirmation doesn't match the password. Please try again."
     end
     @command.change_user_password(password)
   end
@@ -25,9 +27,9 @@ class ChangePassword
   end
 
   def ask_hidden(question)
-    print(question)
-    input = $stdin.noecho(&:gets).chomp
-    puts
-    input
+    @output.print(question)
+    user_input = $stdin.noecho { @input.gets }.chomp
+    @output.puts
+    user_input
   end
 end

--- a/spec/tasks/change_password_spec.rb
+++ b/spec/tasks/change_password_spec.rb
@@ -3,30 +3,25 @@ require "spec_helper"
 app_require "tasks/change_password"
 
 describe ChangePassword do
-  let(:command) { double("command") }
-  let(:new_password) { "new-pw" }
-
-  let(:task) { ChangePassword.new(command) }
+  let(:command) { instance_double(ChangeUserPassword) }
 
   describe "#change_password" do
     it "invokes command with confirmed password" do
-      expect(task).to receive(:ask_hidden).twice
-                                          .and_return(new_password, new_password)
+      output = StringIO.new
+      input = StringIO.new("new-pw\nnew-pw\n")
+      task = ChangePassword.new(command, output: output, input: input)
 
-      expect(command)
-        .to receive(:change_user_password)
-        .with(new_password)
+      expect(command).to receive(:change_user_password).with("new-pw")
 
       task.change_password
     end
 
     it "repeats until a matching confirmation" do
-      expect(task).to receive(:ask_hidden).exactly(2).times
-                                          .and_return(new_password, "", new_password, new_password)
+      output = StringIO.new
+      input = StringIO.new("woops\nnope\nnew-pw\nnew-pw\n")
+      task = ChangePassword.new(command, output: output, input: input)
 
-      expect(command)
-        .to receive(:change_user_password)
-        .with(new_password)
+      expect(command).to receive(:change_user_password).with("new-pw")
 
       task.change_password
     end


### PR DESCRIPTION
This makes it so that we can pass input and output to ChangePassword in
order to test against them, and prevent them from outputting in the
tests.
