### PR TITLE
fix ActiveRecord deprecation warning

### DIFF
--- a/app/repositories/group_repository.rb
+++ b/app/repositories/group_repository.rb
@@ -2,6 +2,6 @@ require_relative "../models/group"
 
 class GroupRepository
   def self.list
-    Group.order("LOWER(name)")
+    Group.order(Group.arel_table[:name].lower)
   end
 end


### PR DESCRIPTION
ActiveRecord no longer wants us to pass SQL fragments to `order`. This
instead makes use of the underlying framework Arel to generate the
query.
