### PR TITLE
Specs: actually execute code in fetch_feed_spec

### DIFF
--- a/spec/tasks/fetch_feed_spec.rb
+++ b/spec/tasks/fetch_feed_spec.rb
@@ -23,7 +23,7 @@ describe FetchFeed do
 
         expect(StoryRepository).not_to receive(:add)
 
-        FetchFeed.new(daring_fireball, parser: parser, client: client)
+        FetchFeed.new(daring_fireball, parser: parser, client: client).fetch
       end
     end
 


### PR DESCRIPTION
The test wasn't actually executing the method under test, so it wasn't
verifying anything.
