### PR TITLE
DB: update schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,67 +10,64 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141102103617) do
+ActiveRecord::Schema.define(version: 2014_11_02_103617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "delayed_jobs", force: :cascade do |t|
-    t.integer  "priority",   default: 0
-    t.integer  "attempts",   default: 0
-    t.text     "handler"
-    t.text     "last_error"
+    t.integer "priority", default: 0
+    t.integer "attempts", default: 0
+    t.text "handler"
+    t.text "last_error"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
-    t.string   "locked_by"
-    t.string   "queue"
+    t.string "locked_by"
+    t.string "queue"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
-
   create_table "feeds", force: :cascade do |t|
-    t.string   "name"
-    t.text     "url"
+    t.string "name"
+    t.text "url"
     t.datetime "last_fetched"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "status"
-    t.integer  "group_id"
+    t.integer "status"
+    t.integer "group_id"
+    t.index ["url"], name: "index_feeds_on_url", unique: true
   end
 
-  add_index "feeds", ["url"], name: "index_feeds_on_url", unique: true, using: :btree
-
   create_table "groups", force: :cascade do |t|
-    t.string   "name",       null: false
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
   create_table "stories", force: :cascade do |t|
-    t.text     "title"
-    t.text     "permalink"
-    t.text     "body"
-    t.integer  "feed_id"
+    t.text "title"
+    t.text "permalink"
+    t.text "body"
+    t.integer "feed_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "published"
-    t.boolean  "is_read"
-    t.boolean  "keep_unread", default: false
-    t.boolean  "is_starred",  default: false
-    t.text     "entry_id"
+    t.boolean "is_read"
+    t.boolean "keep_unread", default: false
+    t.boolean "is_starred", default: false
+    t.text "entry_id"
+    t.index ["entry_id", "feed_id"], name: "index_stories_on_entry_id_and_feed_id", unique: true
   end
 
-  add_index "stories", ["entry_id", "feed_id"], name: "index_stories_on_entry_id_and_feed_id", unique: true, using: :btree
-
   create_table "users", force: :cascade do |t|
-    t.string   "password_digest"
+    t.string "password_digest"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "setup_complete"
-    t.string   "api_key"
+    t.boolean "setup_complete"
+    t.string "api_key"
   end
 
 end


### PR DESCRIPTION
This is auto-generated when I run `rake db:migrate`. It looks like the
formatting just changed some in later versions of ActiveRecord.
