### PR TITLE
Deps: upgrade ActiveRecord to 6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :development, :test do
   gem "timecop"
 end
 
-gem "activerecord", "~> 5.0"
+gem "activerecord"
 gem "bcrypt"
 gem "delayed_job"
 gem "delayed_job_active_record"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.4.5)
-      activesupport (= 5.2.4.5)
-    activerecord (5.2.4.5)
-      activemodel (= 5.2.4.5)
-      activesupport (= 5.2.4.5)
-      arel (>= 9.0)
-    activesupport (5.2.4.5)
+    activemodel (6.1.3.1)
+      activesupport (= 6.1.3.1)
+    activerecord (6.1.3.1)
+      activemodel (= 6.1.3.1)
+      activesupport (= 6.1.3.1)
+    activesupport (6.1.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    arel (9.0.0)
     ast (2.4.2)
     bcrypt (3.1.16)
     byebug (11.1.3)
@@ -55,7 +54,7 @@ GEM
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
     kgio (2.11.3)
@@ -184,13 +183,12 @@ GEM
       tins (~> 1.0)
     thor (1.1.0)
     thread (0.2.2)
-    thread_safe (0.3.6)
     tilt (2.0.10)
     timecop (0.9.4)
     tins (1.28.0)
       sync
-    tzinfo (1.2.9)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (2.0.0)
@@ -200,12 +198,13 @@ GEM
     will_paginate (3.3.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (~> 5.0)
+  activerecord
   bcrypt
   capybara
   coveralls (> 0.8)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,75 +2,72 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141102103617) do
+ActiveRecord::Schema.define(version: 2014_11_02_103617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "delayed_jobs", force: :cascade do |t|
-    t.integer  "priority",   default: 0
-    t.integer  "attempts",   default: 0
-    t.text     "handler"
-    t.text     "last_error"
+    t.integer "priority", default: 0
+    t.integer "attempts", default: 0
+    t.text "handler"
+    t.text "last_error"
     t.datetime "run_at"
     t.datetime "locked_at"
     t.datetime "failed_at"
-    t.string   "locked_by"
-    t.string   "queue"
+    t.string "locked_by"
+    t.string "queue"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
-
   create_table "feeds", force: :cascade do |t|
-    t.string   "name"
-    t.text     "url"
+    t.string "name"
+    t.text "url"
     t.datetime "last_fetched"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "status"
-    t.integer  "group_id"
+    t.integer "status"
+    t.integer "group_id"
+    t.index ["url"], name: "index_feeds_on_url", unique: true
   end
 
-  add_index "feeds", ["url"], name: "index_feeds_on_url", unique: true, using: :btree
-
   create_table "groups", force: :cascade do |t|
-    t.string   "name",       null: false
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
   create_table "stories", force: :cascade do |t|
-    t.text     "title"
-    t.text     "permalink"
-    t.text     "body"
-    t.integer  "feed_id"
+    t.text "title"
+    t.text "permalink"
+    t.text "body"
+    t.integer "feed_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "published"
-    t.boolean  "is_read"
-    t.boolean  "keep_unread", default: false
-    t.boolean  "is_starred",  default: false
-    t.text     "entry_id"
+    t.boolean "is_read"
+    t.boolean "keep_unread", default: false
+    t.boolean "is_starred", default: false
+    t.text "entry_id"
+    t.index ["entry_id", "feed_id"], name: "index_stories_on_entry_id_and_feed_id", unique: true
   end
 
-  add_index "stories", ["entry_id", "feed_id"], name: "index_stories_on_entry_id_and_feed_id", unique: true, using: :btree
-
   create_table "users", force: :cascade do |t|
-    t.string   "password_digest"
+    t.string "password_digest"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "setup_complete"
-    t.string   "api_key"
+    t.boolean "setup_complete"
+    t.string "api_key"
   end
 
 end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -84,7 +84,7 @@ describe "Story" do
 
       expect(story.as_json).to eq({
         body: "story body",
-        created_at: created_at,
+        created_at: created_at.utc.as_json,
         entry_id: "5",
         feed_id: feed.id,
         headline: "the story title",
@@ -95,10 +95,10 @@ describe "Story" do
         lead: "story body",
         permalink: "www.exampoo.com/perma",
         pretty_date: I18n.l(published_at.utc),
-        published: published_at.utc,
+        published: published_at.utc.as_json,
         source: "my feed",
         title: "the story title",
-        updated_at: updated_at
+        updated_at: updated_at.utc.as_json
       }.stringify_keys)
     end
   end


### PR DESCRIPTION
I needed to update the format of the json being returned in the tests.
I'm not sure if it actually ends up changing the result when the dates
are converted to JSON strings, but it doesn't look like anything client
or server relies particularly on the format, so we should be fine.

Also updates the formatting in `schema.rb` by running `rake db:migrate`.
All of the changes look to be cosmetic.
