### PR TITLE
Deps: switch to coveralls_reborn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ end
 
 group :development, :test do
   gem "capybara"
-  gem "coveralls", "> 0.8", require: false
+  gem "coveralls_reborn", require: false
   gem "faker"
   gem "pry-byebug"
   gem "rack-test"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,12 +27,11 @@ GEM
       xpath (~> 3.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
+    coveralls_reborn (0.21.0)
+      simplecov (>= 0.18.1, < 0.22.0)
+      term-ansicolor (~> 1.6)
+      thor (>= 0.20.3, < 2.0)
+      tins (~> 1.16)
     crass (1.0.6)
     delayed_job (4.1.9)
       activesupport (>= 3.0, < 6.2)
@@ -56,7 +55,6 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    json (2.5.1)
     kgio (2.11.3)
     loofah (2.9.1)
       crass (~> 1.0.2)
@@ -152,11 +150,12 @@ GEM
     sax-machine (1.3.2)
     shotgun (0.9.2)
       rack (>= 1.0)
-    simplecov (0.16.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.2)
     sinatra (2.1.0)
       mustermann (~> 1.0)
       rack (~> 2.2)
@@ -207,7 +206,7 @@ DEPENDENCIES
   activerecord
   bcrypt
   capybara
-  coveralls (> 0.8)
+  coveralls_reborn
   delayed_job
   delayed_job_active_record
   faker


### PR DESCRIPTION
The [coveralls gem][gem] hasn't been updated in more than a year. The
[reborn][reborn] is a more up to date version that doesn't lock us down
on an older version of SimpleCov. We may want to consider removing
Coveralls entirely and just using the CI coverage, perhaps also keeping
the artifacts for easy reference.

[gem]: https://github.com/lemurheavy/coveralls-ruby
[reborn]: https://github.com/tagliala/coveralls-ruby-reborn
